### PR TITLE
fix: dist append_profile falls back to disk for external files

### DIFF
--- a/scripts/generate-dist.sh
+++ b/scripts/generate-dist.sh
@@ -284,11 +284,20 @@ append_profile() {
   local key
 
   key="$(profile_key_from_source "$source")"
-  if ! embedded_profile_body "$key" >> "$target"; then
-    echo "Missing profile module: ${source}" >&2
-    exit 1
+  if embedded_profile_body "$key" >> "$target"; then
+    echo "" >> "$target"
+    return
   fi
-  echo "" >> "$target"
+
+  # Fallback: read from disk (needed for --append-profile with external files).
+  if [[ -f "$source" ]]; then
+    cat "$source" >> "$target"
+    echo "" >> "$target"
+    return
+  fi
+
+  echo "Missing profile module: ${source}" >&2
+  exit 1
 }
 
 append_resolved_base_profile() {


### PR DESCRIPTION
The dist's `append_profile()` override only looked up profiles from the embedded case-statement and never fell back to reading from disk. This caused `--append-profile` with any external file (not pre-embedded in the dist) to fail with "Missing profile module".

Add a disk fallback so external files passed via `--append-profile` are read with `cat` when not found in embedded profiles.