### PR TITLE
docs: add copy-paste LLM profile instructions

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Docs', link: '/docs/' },
+      { text: 'LLM Instructions', link: '/llm-instructions.txt' },
       { text: 'Policy Builder', link: '/policy-builder' },
     ],
 
@@ -45,6 +46,7 @@ export default defineConfig({
             { text: 'Isolation Models', link: '/docs/isolation-models' },
             { text: 'Default Assumptions', link: '/docs/default-assumptions' },
             { text: 'Getting Started', link: '/docs/getting-started' },
+            { text: 'Generate a Custom Profile with an LLM', link: '/docs/llm-profile-generator' },
             { text: 'Usage', link: '/docs/usage' },
             { text: 'Options', link: '/docs/options' },
           ],

--- a/docs/.vitepress/theme/HomeContent.vue
+++ b/docs/.vitepress/theme/HomeContent.vue
@@ -305,6 +305,17 @@ const accessRows = [
       </div>
     </div>
   </section>
+
+  <section class="home-section">
+    <div class="home-container">
+      <h2 class="section-title">Generate your own profile with an LLM</h2>
+      <p class="section-sub">Use a ready-made prompt that tells Claude, Codex, Gemini, or another model to inspect the real Safehouse profile templates, ask about your home directory and toolchain, and generate a least-privilege `sandbox-exec` profile for your setup.</p>
+      <div class="cta-card">
+        <p class="muted-text">The guide also tells the LLM to ask about global dotfiles, suggest a durable profile path like <code>~/.config/sandbox-exec.profile</code>, offer a wrapper that grants the current working directory, and add shell shortcuts for your preferred agents.</p>
+        <a class="cta-link" href="/llm-instructions.txt">Open the copy-paste prompt</a>
+      </div>
+    </div>
+  </section>
 </template>
 
 <style scoped>
@@ -363,6 +374,38 @@ const accessRows = [
   font-size: 0.94rem;
   line-height: 1.7;
   margin-top: 16px;
+}
+.muted-text code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.84rem;
+}
+
+.cta-card {
+  border: 1px solid var(--vp-c-border);
+  border-radius: 12px;
+  padding: 22px 24px;
+  background: linear-gradient(180deg, var(--vp-c-bg-alt), rgba(212, 160, 23, 0.05));
+}
+
+.cta-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 16px;
+  padding: 11px 16px;
+  border-radius: 8px;
+  border: 1px solid rgba(212, 160, 23, 0.28);
+  background: rgba(212, 160, 23, 0.08);
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.cta-link:hover {
+  transform: translateY(-1px);
+  border-color: rgba(212, 160, 23, 0.45);
+  background: rgba(212, 160, 23, 0.12);
 }
 
 /* ---- Struck / Scribble ---- */

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -8,8 +8,9 @@ If you are new, follow this order:
 2. [Isolation Models](./isolation-models.md)
 3. [Default Assumptions](./default-assumptions.md)
 4. [Getting Started](./getting-started.md)
-5. [Usage](./usage.md)
-6. [Options](./options.md)
+5. [Generate a Custom Profile with an LLM](./llm-profile-generator.md)
+6. [Usage](./usage.md)
+7. [Options](./options.md)
 
 Then go deeper as needed:
 

--- a/docs/docs/llm-profile-generator.md
+++ b/docs/docs/llm-profile-generator.md
@@ -1,0 +1,100 @@
+# Generate a Custom `sandbox-exec` Profile with an LLM
+
+If you want an LLM to build a machine-specific profile for your own setup, copy the prompt below into Claude, Codex, Gemini, or another model. It tells the model to inspect Agent Safehouse's real profile sources first, then ask for only the minimum information needed to generate a least-privilege `.sb` file.
+
+Direct plain-text version: [llm-instructions.txt](/llm-instructions.txt)
+
+## Inspect These References First
+
+Point the LLM at the real source files, not `dist/`:
+
+- [`profiles/00-base.sb`](https://github.com/eugene1g/agent-safehouse/blob/main/profiles/00-base.sb)
+- [`profiles/10-system-runtime.sb`](https://github.com/eugene1g/agent-safehouse/blob/main/profiles/10-system-runtime.sb)
+- [`profiles/20-network.sb`](https://github.com/eugene1g/agent-safehouse/blob/main/profiles/20-network.sb)
+- [`profiles/30-toolchains/`](https://github.com/eugene1g/agent-safehouse/tree/main/profiles/30-toolchains)
+- [`profiles/40-shared/`](https://github.com/eugene1g/agent-safehouse/tree/main/profiles/40-shared)
+- [`profiles/50-integrations-core/`](https://github.com/eugene1g/agent-safehouse/tree/main/profiles/50-integrations-core)
+- [`profiles/55-integrations-optional/`](https://github.com/eugene1g/agent-safehouse/tree/main/profiles/55-integrations-optional)
+- [`profiles/60-agents/`](https://github.com/eugene1g/agent-safehouse/tree/main/profiles/60-agents)
+- [`profiles/65-apps/`](https://github.com/eugene1g/agent-safehouse/tree/main/profiles/65-apps)
+- [`bin/lib/policy.sh`](https://github.com/eugene1g/agent-safehouse/blob/main/bin/lib/policy.sh)
+- [`bin/safehouse.sh`](https://github.com/eugene1g/agent-safehouse/blob/main/bin/safehouse.sh)
+
+Helpful docs:
+
+- [Policy Architecture](/docs/policy-architecture)
+- [Customization](/docs/customization)
+- [Usage](/docs/usage)
+- [Options](/docs/options)
+
+The source of truth lives in `profiles/` and `bin/`. `dist/` is generated output.
+
+## Copy/Paste Prompt
+
+```md
+I want you to generate a custom macOS `sandbox-exec` profile for my setup.
+
+Before you generate anything, inspect these references to learn the deny-first structure and real profile patterns used by Agent Safehouse:
+- https://github.com/eugene1g/agent-safehouse/blob/main/profiles/00-base.sb
+- https://github.com/eugene1g/agent-safehouse/blob/main/profiles/10-system-runtime.sb
+- https://github.com/eugene1g/agent-safehouse/blob/main/profiles/20-network.sb
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/30-toolchains
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/40-shared
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/50-integrations-core
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/55-integrations-optional
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/60-agents
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/65-apps
+- https://github.com/eugene1g/agent-safehouse/blob/main/bin/lib/policy.sh
+- https://github.com/eugene1g/agent-safehouse/blob/main/bin/safehouse.sh
+
+Use those references as style and capability guides. Prefer the narrowest possible rules and explain which repo profiles influenced your decisions.
+
+Then gather only the minimum inputs you need from me:
+1. My absolute home directory path. Tell me to run `echo $HOME` if I have not given it yet, and use that exact path so the profile grants only what is needed.
+2. Any global files or dotfiles I want my agent to access, such as `~/.gitignore`, `~/.gitignore_global`, `~/.npmrc`, `~/.config`, or other machine-global files. Ask whether each one should be read-only or writable.
+3. My typical tech stack and tooling, for example Node.js, `pnpm`, `npm`, `yarn`, Python, uv, Bun, Go, Rust, Docker, Homebrew, Git, VS Code, Claude Desktop, Codex, Cursor, or browser tooling. Pick only the integrations that match my actual stack.
+4. Where I want to save the profile. Default to `~/.config/sandbox-exec.profile` unless I choose a different path.
+5. Whether I want a small wrapper script that automatically grants access to the current working directory, or git root when relevant, whenever I launch the agent.
+6. Which shell I use (`zsh`, `bash`, `fish`, etc.) and which agent commands I want shortcuts for in my shell config.
+7. Which directories should be read/write, read-only, or fully denied.
+
+After you have enough information, produce:
+- A complete `.sb` profile file.
+- A short explanation of each access grant.
+- A wrapper script, if helpful, that resolves the current working directory and launches `sandbox-exec` with the generated profile.
+- A shell config snippet for my shell (for example `~/.zshrc`) that adds shortcuts for my preferred agents.
+- A short install and verification checklist.
+
+Requirements:
+- Start from deny-by-default.
+- Do not grant my entire home directory unless I explicitly ask for it.
+- Prefer `literal` or narrow `subpath` rules instead of broad recursive access.
+- Keep global dotfile access minimal and explicit.
+- Separate read-only grants from read/write grants.
+- If my stack implies toolchain access, mirror the least-privilege patterns from Agent Safehouse rather than inventing broad permissions.
+- If you are unsure whether something is required, ask me before adding it.
+- Keep the final profile commented and easy to audit.
+
+If a wrapper script is generated, prefer behavior like this:
+- Detect the current working directory with `pwd -P`.
+- Optionally prefer `git rev-parse --show-toplevel` when inside a git repo.
+- Pass that directory into the policy in the narrowest way possible.
+- Keep the script portable and easy to edit.
+
+If shell shortcuts are generated, make them convenient but explicit, for example:
+- `safe-claude`
+- `safe-codex`
+- `safe-cursor`
+
+Use the repo references above to justify the structure of the profile, but output a self-contained result I can save directly to disk.
+```
+
+## Suggested Outcome
+
+The best result is usually:
+
+- one machine-local profile file at `~/.config/sandbox-exec.profile`
+- one small wrapper script that grants the current project directory
+- one shell snippet that adds agent-specific shortcuts in `~/.zshrc`, `~/.bashrc`, or the user's active shell config
+
+That keeps the durable policy in one place while still making everyday agent launches convenient.

--- a/docs/public/llm-instructions.txt
+++ b/docs/public/llm-instructions.txt
@@ -1,0 +1,55 @@
+I want you to generate a custom macOS sandbox-exec profile for my setup.
+
+Before you generate anything, inspect these references to learn the deny-first structure and real profile patterns used by Agent Safehouse:
+- https://github.com/eugene1g/agent-safehouse/blob/main/profiles/00-base.sb
+- https://github.com/eugene1g/agent-safehouse/blob/main/profiles/10-system-runtime.sb
+- https://github.com/eugene1g/agent-safehouse/blob/main/profiles/20-network.sb
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/30-toolchains
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/40-shared
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/50-integrations-core
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/55-integrations-optional
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/60-agents
+- https://github.com/eugene1g/agent-safehouse/tree/main/profiles/65-apps
+- https://github.com/eugene1g/agent-safehouse/blob/main/bin/lib/policy.sh
+- https://github.com/eugene1g/agent-safehouse/blob/main/bin/safehouse.sh
+
+Use those references as style and capability guides. Prefer the narrowest possible rules and explain which repo profiles influenced your decisions.
+
+Then gather only the minimum inputs you need from me:
+1. My absolute home directory path. Tell me to run `echo $HOME` if I have not given it yet, and use that exact path so the profile grants only what is needed.
+2. Any global files or dotfiles I want my agent to access, such as `~/.gitignore`, `~/.gitignore_global`, `~/.npmrc`, `~/.config`, or other machine-global files. Ask whether each one should be read-only or writable.
+3. My typical tech stack and tooling, for example Node.js, `pnpm`, `npm`, `yarn`, Python, uv, Bun, Go, Rust, Docker, Homebrew, Git, VS Code, Claude Desktop, Codex, Cursor, or browser tooling. Pick only the integrations that match my actual stack.
+4. Where I want to save the profile. Default to `~/.config/sandbox-exec.profile` unless I choose a different path.
+5. Whether I want a small wrapper script that automatically grants access to the current working directory, or git root when relevant, whenever I launch the agent.
+6. Which shell I use (`zsh`, `bash`, `fish`, etc.) and which agent commands I want shortcuts for in my shell config.
+7. Which directories should be read/write, read-only, or fully denied.
+
+After you have enough information, produce:
+- A complete `.sb` profile file.
+- A short explanation of each access grant.
+- A wrapper script, if helpful, that resolves the current working directory and launches `sandbox-exec` with the generated profile.
+- A shell config snippet for my shell (for example `~/.zshrc`) that adds shortcuts for my preferred agents.
+- A short install and verification checklist.
+
+Requirements:
+- Start from deny-by-default.
+- Do not grant my entire home directory unless I explicitly ask for it.
+- Prefer `literal` or narrow `subpath` rules instead of broad recursive access.
+- Keep global dotfile access minimal and explicit.
+- Separate read-only grants from read/write grants.
+- If my stack implies toolchain access, mirror the least-privilege patterns from Agent Safehouse rather than inventing broad permissions.
+- If you are unsure whether something is required, ask me before adding it.
+- Keep the final profile commented and easy to audit.
+
+If a wrapper script is generated, prefer behavior like this:
+- Detect the current working directory with `pwd -P`.
+- Optionally prefer `git rev-parse --show-toplevel` when inside a git repo.
+- Pass that directory into the policy in the narrowest way possible.
+- Keep the script portable and easy to edit.
+
+If shell shortcuts are generated, make them convenient but explicit, for example:
+- `safe-claude`
+- `safe-codex`
+- `safe-cursor`
+
+Use the repo references above to justify the structure of the profile, but output a self-contained result I can save directly to disk.


### PR DESCRIPTION
## Why
Users wanted a copy-pasteable prompt they can hand to an LLM to generate a custom `sandbox-exec` profile tailored to their home directory, toolchain, global dotfiles, wrapper scripts, and shell shortcuts.

## What changed
- add a new docs guide explaining how to generate a custom profile with an LLM
- add a raw text asset at `/llm-instructions.txt` for direct copy/paste
- link the new instructions from the docs index, homepage CTA, and top header nav

## Validation
- `pnpm docs:build`