### PR TITLE
Fix container runtime socket deny bypass via unix domain socket connect()

### DIFF
--- a/profiles/50-integrations-core/container-runtime-default-deny.sb
+++ b/profiles/50-integrations-core/container-runtime-default-deny.sb
@@ -23,3 +23,22 @@
     (regex (string-append "^" HOME_DIR "/\\.config/containers/podman/machine/podman\\.sock$"))
     (regex (string-append "^" HOME_DIR "/\\.config/containers/podman/machine/[^/]+/podman\\.sock$"))
 )
+
+;; Docker/Podman clients use connect() on unix domain sockets, which sandbox-exec
+;; classifies as network-outbound — not file-read/write. Without this deny block,
+;; the file-level deny above is bypassed entirely.
+(deny network-outbound
+    (remote unix-socket (path-literal "/var/run/docker.sock"))
+    (remote unix-socket (path-literal "/private/var/run/docker.sock"))
+    (remote unix-socket (path-literal "/var/run/podman/podman.sock"))
+    (remote unix-socket (path-literal "/private/var/run/podman/podman.sock"))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.docker/run/docker\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.rd/docker\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.orbstack/run/docker\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.colima/docker\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.colima/[^/]+/docker\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.local/share/containers/podman/machine/podman\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.local/share/containers/podman/machine/[^/]+/podman\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.config/containers/podman/machine/podman\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.config/containers/podman/machine/[^/]+/podman\\.sock$")))
+)

--- a/profiles/55-integrations-optional/docker.sb
+++ b/profiles/55-integrations-optional/docker.sb
@@ -14,6 +14,18 @@
     (home-literal "/.rd/docker.sock")                                      ;; Rancher Desktop socket.
 )
 
+;; Re-allow connect() on Docker unix sockets (matches the network-outbound deny
+;; in container-runtime-default-deny.sb).
+(allow network-outbound
+    (remote unix-socket (path-literal "/var/run/docker.sock"))
+    (remote unix-socket (path-literal "/private/var/run/docker.sock"))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.docker/run/docker\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.orbstack/run/docker\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.colima/docker\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.colima/[^/]+/docker\\.sock$")))
+    (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.rd/docker\\.sock$")))
+)
+
 ;; OrbStack (Docker Desktop alternative) — shell completions and CLI helpers.
 (allow file-read*
     (subpath "/Applications/OrbStack.app/Contents/Resources/completions")  ;; Zsh/bash completions sourced during shell init.


### PR DESCRIPTION
## Summary

- The existing `file-read* file-write*` deny on container socket paths is ineffective because Docker/Podman use `connect()` on unix domain sockets, which sandbox-exec classifies as `network-outbound` — not a file operation
- A sandboxed agent can run `docker run -v $HOME:/host alpine cat /host/.ssh/id_rsa` and read any host file — full sandbox escape
- Adds `network-outbound` deny rules in `container-runtime-default-deny.sb` for all socket paths
- Adds matching `network-outbound` allow rules in `docker.sb` for when Docker is explicitly opted in via `--enable=docker`

## Test plan

- [ ] `safehouse -- docker ps` should fail with "operation not permitted"
- [ ] `safehouse -- docker run --rm hello-world` should fail
- [ ] `safehouse -- docker run --rm -v $HOME:/host alpine cat /host/.ssh/id_rsa` should fail
- [ ] `safehouse --enable=docker -- docker ps` should still work

Fixes #19