### PR TITLE
Add Puppeteer cache path to node toolchain profile

### DIFF
--- a/profiles/30-toolchains/node.sb
+++ b/profiles/30-toolchains/node.sb
@@ -54,6 +54,7 @@
     ;; browser automation / test runners
     (home-subpath "/Library/Caches/ms-playwright")
     (home-subpath "/Library/Caches/Cypress")
+    (home-subpath "/.cache/puppeteer")
 
     ;; Node ecosystem caches used by CLIs and language tooling
     (home-subpath "/Library/Caches/typescript")


### PR DESCRIPTION
## Summary
- Puppeteer stores downloaded Chrome binaries in `~/.cache/puppeteer/`, but no profile grants access to this path
- Chrome fails with `dlopen ... blocked by sandbox` when launched via Puppeteer under safehouse
- Adds `~/.cache/puppeteer` alongside existing Playwright (`~/Library/Caches/ms-playwright`) and Cypress grants in `30-toolchains/node.sb`

## Test plan
- `tests/run.sh` passes (704 pass, 6 pre-existing failures unrelated to this change)
- Verified that `safehouse --enable=chromium-full --stdout` now includes `~/.cache/puppeteer` in generated policy