### PR TITLE
fix: tighten Java sandbox config

### DIFF
--- a/dist/Claude.app.sandboxed-offline.command
+++ b/dist/Claude.app.sandboxed-offline.command
@@ -473,8 +473,15 @@ emit_embedded_policy_template() {
 
 ;; Includes common Maven/Gradle/SBT/Coursier and Java runtime manager locations.
 
-(allow file-read* file-write*
+;; System-wide JDK/JRE bundles are read-only: agents need to discover and execute
+;; them, but must not modify globally installed runtimes under /Library.
+(allow file-read*
     (subpath "/Library/Java")                                         ;; System-wide JDK/JRE bundles live here on macOS and are probed by /usr/bin/java.
+)
+
+;; User-local Java state remains read-write for runtime managers, caches, and
+;; per-user JDK installs under ~/Library/Java.
+(allow file-read* file-write*
     (home-subpath "/.m2")
     (home-subpath "/.gradle")
     (home-subpath "/.ivy2")

--- a/dist/profiles/safehouse-for-apps.generated.sb
+++ b/dist/profiles/safehouse-for-apps.generated.sb
@@ -404,8 +404,15 @@
 
 ;; Includes common Maven/Gradle/SBT/Coursier and Java runtime manager locations.
 
-(allow file-read* file-write*
+;; System-wide JDK/JRE bundles are read-only: agents need to discover and execute
+;; them, but must not modify globally installed runtimes under /Library.
+(allow file-read*
     (subpath "/Library/Java")                                         ;; System-wide JDK/JRE bundles live here on macOS and are probed by /usr/bin/java.
+)
+
+;; User-local Java state remains read-write for runtime managers, caches, and
+;; per-user JDK installs under ~/Library/Java.
+(allow file-read* file-write*
     (home-subpath "/.m2")
     (home-subpath "/.gradle")
     (home-subpath "/.ivy2")

--- a/dist/profiles/safehouse.generated.sb
+++ b/dist/profiles/safehouse.generated.sb
@@ -404,8 +404,15 @@
 
 ;; Includes common Maven/Gradle/SBT/Coursier and Java runtime manager locations.
 
-(allow file-read* file-write*
+;; System-wide JDK/JRE bundles are read-only: agents need to discover and execute
+;; them, but must not modify globally installed runtimes under /Library.
+(allow file-read*
     (subpath "/Library/Java")                                         ;; System-wide JDK/JRE bundles live here on macOS and are probed by /usr/bin/java.
+)
+
+;; User-local Java state remains read-write for runtime managers, caches, and
+;; per-user JDK installs under ~/Library/Java.
+(allow file-read* file-write*
     (home-subpath "/.m2")
     (home-subpath "/.gradle")
     (home-subpath "/.ivy2")

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -465,8 +465,15 @@ __SAFEHOUSE_EMBEDDED_profiles_30_toolchains_go_sb__
 
 ;; Includes common Maven/Gradle/SBT/Coursier and Java runtime manager locations.
 
-(allow file-read* file-write*
+;; System-wide JDK/JRE bundles are read-only: agents need to discover and execute
+;; them, but must not modify globally installed runtimes under /Library.
+(allow file-read*
     (subpath "/Library/Java")                                         ;; System-wide JDK/JRE bundles live here on macOS and are probed by /usr/bin/java.
+)
+
+;; User-local Java state remains read-write for runtime managers, caches, and
+;; per-user JDK installs under ~/Library/Java.
+(allow file-read* file-write*
     (home-subpath "/.m2")
     (home-subpath "/.gradle")
     (home-subpath "/.ivy2")

--- a/profiles/30-toolchains/java.sb
+++ b/profiles/30-toolchains/java.sb
@@ -6,8 +6,15 @@
 
 ;; Includes common Maven/Gradle/SBT/Coursier and Java runtime manager locations.
 
-(allow file-read* file-write*
+;; System-wide JDK/JRE bundles are read-only: agents need to discover and execute
+;; them, but must not modify globally installed runtimes under /Library.
+(allow file-read*
     (subpath "/Library/Java")                                         ;; System-wide JDK/JRE bundles live here on macOS and are probed by /usr/bin/java.
+)
+
+;; User-local Java state remains read-write for runtime managers, caches, and
+;; per-user JDK installs under ~/Library/Java.
+(allow file-read* file-write*
     (home-subpath "/.m2")
     (home-subpath "/.gradle")
     (home-subpath "/.ivy2")

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -162,6 +162,67 @@ assert_policy_not_contains() {
   fi
 }
 
+policy_allow_header_for_entry() {
+  local policy="$1"
+  local entry="$2"
+  local entry_line
+
+  entry_line="$(awk -v needle="$entry" 'index($0, needle) { print NR; exit }' "$policy")"
+  if [[ -z "$entry_line" ]]; then
+    return 1
+  fi
+
+  awk -v target="$entry_line" '
+    NR <= target && /^\(allow / { header = $0 }
+    END {
+      if (header == "") {
+        exit 1
+      }
+      print header
+    }
+  ' "$policy"
+}
+
+assert_policy_allow_header_contains() {
+  local policy="$1"
+  local description="$2"
+  local entry="$3"
+  local expected="$4"
+  local header
+
+  header="$(policy_allow_header_for_entry "$policy" "$entry" || true)"
+  if [[ -z "$header" ]]; then
+    log_fail "$description (policy entry not found: $entry)"
+    return
+  fi
+
+  if [[ "$header" == *"$expected"* ]]; then
+    log_pass "$description"
+  else
+    log_fail "$description (expected allow header to contain: $expected)"
+  fi
+}
+
+assert_policy_allow_header_not_contains() {
+  local policy="$1"
+  local description="$2"
+  local entry="$3"
+  local forbidden="$4"
+  local header
+
+  header="$(policy_allow_header_for_entry "$policy" "$entry" || true)"
+  if [[ -z "$header" ]]; then
+    log_fail "$description (policy entry not found: $entry)"
+    return
+  fi
+
+  if [[ "$header" == *"$forbidden"* ]]; then
+    log_fail "$description (expected allow header to omit: $forbidden)"
+  else
+    log_pass "$description"
+  fi
+}
+
 assert_policy_order_literal() {
   local policy="$1"
   local description="$2"

--- a/tests/sections/50-policy-behavior.sh
+++ b/tests/sections/50-policy-behavior.sh
@@ -65,6 +65,9 @@ run_section_policy_behavior() {
   assert_policy_not_contains "$POLICY_DEFAULT" "default policy omits Xcode integration profile" ";; Integration: Xcode"
   assert_policy_not_contains "$POLICY_DEFAULT" "default policy no longer grants broad file-read* access to /private/var/run" "Resolver/daemon sockets and pid files used by networking flows."
   assert_policy_contains "$POLICY_DEFAULT" "default policy includes metadata-only /private/var/run grant" "Metadata traversal for /private/var/run socket namespace."
+  assert_policy_allow_header_contains "$POLICY_DEFAULT" "default policy grants read access to system /Library/Java" "(subpath \"/Library/Java\")" "file-read*"
+  assert_policy_allow_header_not_contains "$POLICY_DEFAULT" "default policy keeps system /Library/Java read-only" "(subpath \"/Library/Java\")" "file-write*"
+  assert_policy_allow_header_contains "$POLICY_DEFAULT" "default policy keeps user ~/Library/Java read-write" "(home-subpath \"/Library/Java\")" "file-write*"
 
   policy_agent_browser="${TEST_CWD}/policy-feature-agent-browser.sb"
   policy_browser_native_messaging="${TEST_CWD}/policy-feature-browser-native-messaging.sb"


### PR DESCRIPTION
## Summary
- make system `/Library/Java` read-only while keeping `~/Library/Java` writable
- add policy regression coverage so the system vs user Java split stays enforced
- regenerate dist artifacts after the Java policy change

## Why
Issue #10 reported that the JVM startup fix restored broader-than-needed write access to system Java installs. This change keeps the startup allowances but narrows the Java policy back to least privilege.

## Verification
- `./tests/run.sh`