### PR TITLE
feat(chromium): extend chromium-full for system Chrome launches

### DIFF
--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -1047,8 +1047,8 @@ __SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_browser_native_messaging_
       cat <<'__SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_chromium_full_sb__'
 ;; ---------------------------------------------------------------------------
 ;; Integration: Chromium Full
-;; Additional headed/full-window Chrome for Testing allowances layered on top
-;; of Chromium Headless.
+;; Additional full-browser Chrome channel allowances layered on top of
+;; Chromium Headless.
 ;; Source: 55-integrations-optional/chromium-full.sb
 ;; #safehouse-test-id:chromium-full-integration#
 ;; #safehouse-test-id:chromium-full-rendezvous#
@@ -1056,34 +1056,51 @@ __SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_browser_native_messaging_
 ;; $$require=55-integrations-optional/chromium-headless.sb$$
 ;; ---------------------------------------------------------------------------
 
-;; Keep this integration scoped to the extra probes observed from headed Chrome
-;; for Testing launches. Headless Chromium startup allowances continue to come
-;; from the shared chromium-headless integration.
+;; Keep this integration scoped to the extra probes observed from full-browser
+;; Chrome-family launches on macOS (regular Google Chrome plus Chrome for
+;; Testing). Headless Chromium startup allowances continue to come from the
+;; shared chromium-headless integration.
+;;
+;; Like Electron, system Chrome app bundles may still need `--no-sandbox` at
+;; the browser launch layer. Chrome's internal helper sandbox re-init is
+;; blocked once Safehouse is already enforcing the outer Seatbelt sandbox.
 
 (allow file-read-metadata
     (home-literal "/Library/Application Support/Google")
     (home-literal "/Library/Application Support/Google/Chrome")
+    (home-literal "/Library/Application Support/Google/Chrome/Crashpad")
     (home-literal "/Library/Application Support/Google/Chrome for Testing")
     (home-literal "/Library/Application Support/Google/Chrome for Testing/Crashpad")
     (home-literal "/Library/Google")
 )
 
 (allow file-read*
+    (literal "/Applications")                                          ;; Full Chrome launches resolve the system Google Chrome bundle from /Applications.
+    (subpath "/Applications/Google Chrome.app")                        ;; Allow Chrome stable bundle frameworks/resources when the browser is launched from the app bundle.
+    (literal "/System")                                                ;; Compatibility aliases seen in some bundle/framework resolution flows.
+    (literal "/System/Volumes")
+    (literal "/System/Volumes/Data")
+    (literal "/System/Volumes/Data/Applications")
+    (subpath "/System/Volumes/Data/Applications/Google Chrome.app")
     (literal "/Library")                                              ;; Headed Chrome probes the Library root during desktop app bootstrap.
+    (home-literal "/Library/Preferences/com.google.Chrome.plist")
     (home-literal "/Library/Preferences/com.google.chrome.for.testing.plist")
     (home-literal "/Library/Google/Google Chrome Brand.plist")
 )
 
 (allow file-read* file-write*
-    (home-literal "/Library/Application Support/Google/Chrome/DevToolsActivePort")        ;; Playwright-style full-browser launches wait on this exact DevTools handshake file.
+    (home-literal "/Library/Application Support/Google/Chrome/DevToolsActivePort")        ;; Full-browser Chrome launches wait on this exact DevTools handshake file.
+    (home-subpath "/Library/Application Support/Google/Chrome/Crashpad")                   ;; Chrome stable keeps Crashpad state under the regular Google Chrome app-support tree.
     (home-subpath "/Library/Application Support/Google/Chrome for Testing/Crashpad")       ;; Crashpad keeps its database and metadata under the Chrome for Testing app-support tree.
 )
 
 (allow mach-register
+    (global-name-regex #"^com\.google\.Chrome\.MachPortRendezvousServer\.")
     (global-name-regex #"^com\.google\.chrome\.for\.testing\.MachPortRendezvousServer\.")
 )
 
 (allow mach-lookup
+    (global-name-regex #"^com\.google\.Chrome\.MachPortRendezvousServer\.")
     (global-name-regex #"^com\.google\.chrome\.for\.testing\.MachPortRendezvousServer\.")
     (global-name "com.apple.pasteboard.1")
     (global-name "com.apple.system.opendirectoryd.api")

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -24,6 +24,8 @@
 - `kubectl`
 - `macos-gui`
 - `electron` (implies `macos-gui`)
+- `chromium-headless`
+- `chromium-full` (implies `chromium-headless`)
 - `ssh`
 - `spotlight`
 - `cleanshot`

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -115,6 +115,16 @@ safehouse --workdir=~/server --enable=electron,all-agents,wide-read -- "/Applica
 
 Troubleshooting: `forbidden-sandbox-reinit` or `sandbox initialization failed: Operation not permitted` usually means nested sandbox re-init was attempted; launch with `--no-sandbox`.
 
+## Chromium
+
+Use `--enable=chromium-full` when a launcher needs the system Google Chrome
+bundle or Chrome for Testing bundle under Safehouse.
+
+If browser logs still show `sandbox initialization failed: Operation not
+permitted`, Chrome is trying to re-initialize its own inner Seatbelt sandbox.
+That is not fixable with extra Safehouse allow rules; pass `--no-sandbox` to
+the browser launch layer.
+
 ## Inspect Policy Output
 
 ```bash

--- a/profiles/55-integrations-optional/chromium-full.sb
+++ b/profiles/55-integrations-optional/chromium-full.sb
@@ -1,7 +1,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Integration: Chromium Full
-;; Additional headed/full-window Chrome for Testing allowances layered on top
-;; of Chromium Headless.
+;; Additional full-browser Chrome channel allowances layered on top of
+;; Chromium Headless.
 ;; Source: 55-integrations-optional/chromium-full.sb
 ;; #safehouse-test-id:chromium-full-integration#
 ;; #safehouse-test-id:chromium-full-rendezvous#
@@ -9,34 +9,51 @@
 ;; $$require=55-integrations-optional/chromium-headless.sb$$
 ;; ---------------------------------------------------------------------------
 
-;; Keep this integration scoped to the extra probes observed from headed Chrome
-;; for Testing launches. Headless Chromium startup allowances continue to come
-;; from the shared chromium-headless integration.
+;; Keep this integration scoped to the extra probes observed from full-browser
+;; Chrome-family launches on macOS (regular Google Chrome plus Chrome for
+;; Testing). Headless Chromium startup allowances continue to come from the
+;; shared chromium-headless integration.
+;;
+;; Like Electron, system Chrome app bundles may still need `--no-sandbox` at
+;; the browser launch layer. Chrome's internal helper sandbox re-init is
+;; blocked once Safehouse is already enforcing the outer Seatbelt sandbox.
 
 (allow file-read-metadata
     (home-literal "/Library/Application Support/Google")
     (home-literal "/Library/Application Support/Google/Chrome")
+    (home-literal "/Library/Application Support/Google/Chrome/Crashpad")
     (home-literal "/Library/Application Support/Google/Chrome for Testing")
     (home-literal "/Library/Application Support/Google/Chrome for Testing/Crashpad")
     (home-literal "/Library/Google")
 )
 
 (allow file-read*
+    (literal "/Applications")                                          ;; Full Chrome launches resolve the system Google Chrome bundle from /Applications.
+    (subpath "/Applications/Google Chrome.app")                        ;; Allow Chrome stable bundle frameworks/resources when the browser is launched from the app bundle.
+    (literal "/System")                                                ;; Compatibility aliases seen in some bundle/framework resolution flows.
+    (literal "/System/Volumes")
+    (literal "/System/Volumes/Data")
+    (literal "/System/Volumes/Data/Applications")
+    (subpath "/System/Volumes/Data/Applications/Google Chrome.app")
     (literal "/Library")                                              ;; Headed Chrome probes the Library root during desktop app bootstrap.
+    (home-literal "/Library/Preferences/com.google.Chrome.plist")
     (home-literal "/Library/Preferences/com.google.chrome.for.testing.plist")
     (home-literal "/Library/Google/Google Chrome Brand.plist")
 )
 
 (allow file-read* file-write*
-    (home-literal "/Library/Application Support/Google/Chrome/DevToolsActivePort")        ;; Playwright-style full-browser launches wait on this exact DevTools handshake file.
+    (home-literal "/Library/Application Support/Google/Chrome/DevToolsActivePort")        ;; Full-browser Chrome launches wait on this exact DevTools handshake file.
+    (home-subpath "/Library/Application Support/Google/Chrome/Crashpad")                   ;; Chrome stable keeps Crashpad state under the regular Google Chrome app-support tree.
     (home-subpath "/Library/Application Support/Google/Chrome for Testing/Crashpad")       ;; Crashpad keeps its database and metadata under the Chrome for Testing app-support tree.
 )
 
 (allow mach-register
+    (global-name-regex #"^com\.google\.Chrome\.MachPortRendezvousServer\.")
     (global-name-regex #"^com\.google\.chrome\.for\.testing\.MachPortRendezvousServer\.")
 )
 
 (allow mach-lookup
+    (global-name-regex #"^com\.google\.Chrome\.MachPortRendezvousServer\.")
     (global-name-regex #"^com\.google\.chrome\.for\.testing\.MachPortRendezvousServer\.")
     (global-name "com.apple.pasteboard.1")
     (global-name "com.apple.system.opendirectoryd.api")

--- a/tests/sections/20-integrations.sh
+++ b/tests/sections/20-integrations.sh
@@ -144,13 +144,21 @@ run_section_integrations() {
     "(global-name \"com.apple.pasteboard.1\")" \
     "(global-name \"com.apple.system.opendirectoryd.api\")" \
     "(global-name \"com.apple.ctkd.token-client\")" \
+    "/Applications/Google Chrome.app" \
+    "/System/Volumes/Data/Applications/Google Chrome.app" \
+    "/Library/Preferences/com.google.Chrome.plist" \
     "/Library/Preferences/com.google.chrome.for.testing.plist" \
     "/Library/Application Support/Google/Chrome/DevToolsActivePort" \
+    "/Library/Application Support/Google/Chrome/Crashpad" \
     "/Library/Application Support/Google/Chrome for Testing/Crashpad" \
+    "com\\.google\\.Chrome\\.MachPortRendezvousServer" \
     "com\\.google\\.chrome\\.for\\.testing\\.MachPortRendezvousServer"; do
     assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes required grant/marker (${chromium_full_marker})" "$chromium_full_marker"
   done
   assert_policy_not_contains "$policy_chromium_full" "--enable=chromium-full does not include agent-browser profile" "#safehouse-test-id:agent-browser-integration#"
+
+  assert_allowed_if_exists "$policy_chromium_full" "--enable=chromium-full allows read access to Google Chrome.app bundle when installed" "/Applications/Google Chrome.app" /bin/ls "/Applications/Google Chrome.app"
+  assert_allowed_if_exists "$policy_chromium_full" "--enable=chromium-full allows Google Chrome Crashpad state when present" "${HOME}/Library/Application Support/Google/Chrome/Crashpad" /bin/ls "${HOME}/Library/Application Support/Google/Chrome/Crashpad"
 
   assert_policy_contains "$POLICY_MACOS_GUI" "--enable=macos-gui includes macOS GUI integration profile" ";; Integration: macOS GUI"
   for macos_gui_marker in \

--- a/tests/sections/50-policy-behavior.sh
+++ b/tests/sections/50-policy-behavior.sh
@@ -11,6 +11,7 @@ run_section_policy_behavior() {
   local policy_override_same_literal policy_override_subpath_literal policy_override_wide_read
   local append_override_same_literal append_override_subpath_literal append_override_wide_read
   local override_test_dir override_literal_file override_subpath_dir override_subpath_allowed_file override_subpath_blocked_file override_wide_read_file
+  local chrome_framework
 
   section_begin "Feature Toggles"
   assert_policy_not_contains "$POLICY_DEFAULT" "default policy omits Docker integration profile marker" ";; Integration: Docker"
@@ -107,15 +108,27 @@ run_section_policy_behavior() {
 
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Chromium Full profile marker" "#safehouse-test-id:chromium-full-integration#"
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Chromium Full rendezvous marker" "#safehouse-test-id:chromium-full-rendezvous#"
+  assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Google Chrome app bundle grant" "/Applications/Google Chrome.app"
+  assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Data-backed Google Chrome app bundle grant" "/System/Volumes/Data/Applications/Google Chrome.app"
+  assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Google Chrome prefs grant" "/Library/Preferences/com.google.Chrome.plist"
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Chrome for Testing prefs grant" "/Library/Preferences/com.google.chrome.for.testing.plist"
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Chrome DevToolsActivePort grant" "/Library/Application Support/Google/Chrome/DevToolsActivePort"
+  assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Google Chrome Crashpad grant" "/Library/Application Support/Google/Chrome/Crashpad"
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Chrome Crashpad grant" "/Library/Application Support/Google/Chrome for Testing/Crashpad"
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes pasteboard lookup grant" "(global-name \"com.apple.pasteboard.1\")"
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes OpenDirectory lookup grant" "(global-name \"com.apple.system.opendirectoryd.api\")"
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes token-client lookup grant" "(global-name \"com.apple.ctkd.token-client\")"
+  assert_policy_contains "$policy_chromium_full" "--enable=chromium-full includes Google Chrome mach rendezvous grant" "com\\.google\\.Chrome\\.MachPortRendezvousServer"
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full implicitly injects Chromium Headless integration" "#safehouse-test-id:chromium-headless-integration#"
   assert_policy_contains "$policy_chromium_full" "--enable=chromium-full preamble reports Chromium Headless as implicitly injected" "Optional integrations implicitly injected: chromium-headless"
   assert_policy_not_contains "$policy_chromium_full" "--enable=chromium-full does not include agent-browser state grant" "(home-subpath \"/.agent-browser\")"
+  assert_denied_if_exists "$POLICY_DEFAULT" "read Google Chrome app bundle denied by default" "/Applications/Google Chrome.app" /usr/bin/stat "/Applications/Google Chrome.app"
+  assert_allowed_if_exists "$policy_chromium_full" "read Google Chrome app bundle allowed with --enable=chromium-full" "/Applications/Google Chrome.app" /usr/bin/stat "/Applications/Google Chrome.app"
+  for chrome_framework in /Applications/Google\ Chrome.app/Contents/Frameworks/Google\ Chrome\ Framework.framework/Versions/*/Google\ Chrome\ Framework; do
+    [[ -e "$chrome_framework" ]] || continue
+    assert_denied_if_exists "$POLICY_DEFAULT" "read Google Chrome framework denied by default (${chrome_framework})" "$chrome_framework" /usr/bin/stat "$chrome_framework"
+    assert_allowed_if_exists "$policy_chromium_full" "read Google Chrome framework allowed with --enable=chromium-full (${chrome_framework})" "$chrome_framework" /usr/bin/stat "$chrome_framework"
+  done
 
   assert_policy_contains "$policy_agent_browser" "--enable=agent-browser includes Agent Browser profile marker" "#safehouse-test-id:agent-browser-integration#"
   assert_policy_contains "$policy_agent_browser" "--enable=agent-browser includes agent-browser state grant" "(home-subpath \"/.agent-browser\")"


### PR DESCRIPTION
## Why
`chromium-full` covered Chrome for Testing, but full Chrome-family launches on macOS also need access to the system Google Chrome app bundle, its preferences, Crashpad state, and the stable-channel Mach rendezvous names.

## What changed
- extend `chromium-full` to cover the system Google Chrome app bundle and Data-backed alias path
- allow the stable-channel preference plist, Crashpad state, and Mach rendezvous names
- document when to use `--enable=chromium-full` and the remaining `--no-sandbox` requirement
- add policy and runtime coverage for the new Chrome stable paths

## Validation
- `./scripts/generate-dist.sh`
- `./tests/run.sh`
