### PR TITLE
feat: inject APP_SANDBOX_CONTAINER_ID into sandboxed environment

### DIFF
--- a/bin/lib/cli.sh
+++ b/bin/lib/cli.sh
@@ -471,6 +471,8 @@ main() {
     execution_environment=("${env_pass_merged_exec_environment[@]}")
   fi
 
+  execution_environment+=("APP_SANDBOX_CONTAINER_ID=agent-safehouse")
+
   sandbox-exec -f "$policy_path" -- /usr/bin/env -i "${execution_environment[@]}" "${command_args[@]}"
   status=$?
   set -e


### PR DESCRIPTION
## Summary
- Injects `APP_SANDBOX_CONTAINER_ID=agent-safehouse` into the execution environment before launching `sandbox-exec`
- Follows the macOS convention for sandbox container identification, letting sandboxed processes detect and identify the sandbox they're running in
- Tools can check this variable to adapt behavior (e.g., skip operations that will be denied, choose sandbox-compatible paths)

## Test plan
- [ ] Launch a command via `safehouse` and verify `echo $APP_SANDBOX_CONTAINER_ID` outputs `agent-safehouse`
- [ ] Verify existing env-pass and profile-default env merging still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)