### PR TITLE
test: harden gemini e2e response timing

### DIFF
--- a/tests/e2e/agent_tui_harness.bash
+++ b/tests/e2e/agent_tui_harness.bash
@@ -34,10 +34,13 @@ sft_agent_tui_setup_test_env() {
   AGENT_TUI_RESPONSE_TIMEOUT_SECS="${SAFEHOUSE_AGENT_TUI_RESPONSE_TIMEOUT_SECS:-20}"
   AGENT_TUI_PROMPT_VISIBLE_TIMEOUT_SECS="${SAFEHOUSE_AGENT_TUI_PROMPT_VISIBLE_TIMEOUT_SECS:-5}"
   AGENT_TUI_POLL_INTERVAL_SECS="${SAFEHOUSE_AGENT_TUI_POLL_INTERVAL_SECS:-0.2}"
+  AGENT_TUI_PRE_PROMPT_DELAY_SECS="${SAFEHOUSE_AGENT_TUI_PRE_PROMPT_DELAY_SECS:-0}"
   AGENT_TUI_SUBMIT_DELAY_SECS="${SAFEHOUSE_AGENT_TUI_SUBMIT_DELAY_SECS:-0.3}"
   AGENT_TUI_KEEP_SESSION="${SAFEHOUSE_AGENT_TUI_KEEP_SESSION:-0}"
   AGENT_TUI_KEEP_SESSION_ON_FAIL="${SAFEHOUSE_AGENT_TUI_KEEP_SESSION_ON_FAIL:-0}"
   AGENT_TUI_PRE_PROMPT_KEYS=()
+  AGENT_TUI_PROMPT_SEND_MODE="${SAFEHOUSE_AGENT_TUI_PROMPT_SEND_MODE:-bulk}"
+  AGENT_TUI_PROMPT_CHAR_DELAY_SECS="${SAFEHOUSE_AGENT_TUI_PROMPT_CHAR_DELAY_SECS:-0.03}"
   AGENT_TUI_SUBMIT_KEYS=(Enter)
   AGENT_TUI_PROMPT_TEXT="What is the capital of England? Reply with only the city name."
   AGENT_TUI_PROMPT_VISIBLE_MODE="literal"
@@ -497,6 +500,23 @@ sft_agent_tui_wait_for_prompt_visible() {
   esac
 }
 
+sft_agent_tui_send_prompt_text() {
+  local send_mode="${AGENT_TUI_PROMPT_SEND_MODE:-bulk}"
+
+  case "${send_mode}" in
+    ""|bulk)
+      sft_tmux_send_text "${AGENT_TUI_PROMPT_TEXT}"
+      ;;
+    slow)
+      sft_tmux_send_text_slow "${AGENT_TUI_PROMPT_TEXT}" "${AGENT_TUI_PROMPT_CHAR_DELAY_SECS:-0.03}"
+      ;;
+    *)
+      printf 'unsupported AGENT_TUI_PROMPT_SEND_MODE: %s\n' "${send_mode}" >&2
+      return 1
+      ;;
+  esac
+}
+
 sft_tmux_assert_roundtrip() {
   local key_name=""
 
@@ -508,7 +528,10 @@ sft_tmux_assert_roundtrip() {
     }
   done
 
-  sft_tmux_send_text "${AGENT_TUI_PROMPT_TEXT}" || {
+  if [[ "${AGENT_TUI_PRE_PROMPT_DELAY_SECS:-0}" != "0" && "${AGENT_TUI_PRE_PROMPT_DELAY_SECS:-0}" != "0.0" ]]; then
+    sleep "${AGENT_TUI_PRE_PROMPT_DELAY_SECS}"
+  fi
+  sft_agent_tui_send_prompt_text || {
       AGENT_TUI_FAILED=1
       return 1
     }

--- a/tests/e2e/gemini.bats
+++ b/tests/e2e/gemini.bats
@@ -81,6 +81,11 @@ configure_agent_tui() {
   # submit even when the input buffer is ready, so rely on the roundtrip token
   # instead of a pre-submit prompt echo.
   AGENT_TUI_PROMPT_VISIBLE_MODE="none"
+  # The ready screen can appear before Gemini consistently accepts injected
+  # input on busy CI runners, so wait briefly and type more conservatively.
+  AGENT_TUI_PRE_PROMPT_DELAY_SECS=1
+  AGENT_TUI_PROMPT_SEND_MODE="slow"
+  AGENT_TUI_PROMPT_CHAR_DELAY_SECS=0.05
   # Give Gemini's hidden input buffer extra time to absorb the injected text
   # before Enter on busy CI runners.
   AGENT_TUI_SUBMIT_DELAY_SECS=1

--- a/tests/e2e/kilo-code.bats
+++ b/tests/e2e/kilo-code.bats
@@ -62,6 +62,12 @@ configure_agent_tui() {
   # Kilo keeps the placeholder visible in tmux captures instead of echoing the
   # full typed prompt before submit, so the response token is the stable signal.
   AGENT_TUI_PROMPT_VISIBLE_MODE="none"
+  # The ready screen can appear before Kilo consistently accepts injected
+  # input on busy CI runners, so wait briefly and type more conservatively.
+  AGENT_TUI_PRE_PROMPT_DELAY_SECS=1
+  AGENT_TUI_PROMPT_SEND_MODE="slow"
+  AGENT_TUI_PROMPT_CHAR_DELAY_SECS=0.05
+  AGENT_TUI_SUBMIT_DELAY_SECS=1
 }
 
 handle_startup_gates() {

--- a/tests/e2e/tmux_utils.bash
+++ b/tests/e2e/tmux_utils.bash
@@ -4,6 +4,7 @@
 #   sft_tmux_start_session command [args...]
 #   sft_tmux_capture
 #   sft_tmux_send_text text
+#   sft_tmux_send_text_slow text [char_delay_secs]
 #   sft_tmux_send_keys key [key ...]
 #   sft_tmux_wait_until text [timeout_secs] [poll_secs]
 #   sft_tmux_wait_until_regex pattern [timeout_secs] [poll_secs]
@@ -217,6 +218,28 @@ sft_tmux_send_text() {
   }
 
   tmux send-keys -t "${SFT_TMUX_CURRENT_SESSION}" -l -- "${input_text}"
+}
+
+sft_tmux_send_text_slow() {
+  local input_text="${1:-}"
+  local char_delay_secs="${2:-0.03}"
+  local idx=0
+  local char=""
+
+  sft_tmux_require_current_session || return 1
+  [[ -n "${input_text}" ]] || {
+    printf 'usage: sft_tmux_send_text_slow input_text [char_delay_secs]\n' >&2
+    return 1
+  }
+
+  while (( idx < ${#input_text} )); do
+    char="${input_text:idx:1}"
+    tmux send-keys -t "${SFT_TMUX_CURRENT_SESSION}" -l -- "${char}"
+    idx=$((idx + 1))
+    if [[ "${char_delay_secs}" != "0" && "${char_delay_secs}" != "0.0" ]]; then
+      sleep "${char_delay_secs}"
+    fi
+  done
 }
 
 sft_tmux_send_keys() {

--- a/tests/e2e/tmux_utils.bats
+++ b/tests/e2e/tmux_utils.bats
@@ -62,3 +62,22 @@ load agent_tui_harness.bash
   sft_tmux_wait_until "Ready" 2 0.1
   sft_tmux_assert_roundtrip
 }
+
+@test "[E2E-TUI] pre-prompt delay and slow typing tolerate late input readiness" {
+  local fake_agent_code=""
+
+  sft_require_cmd_or_skip "python3"
+
+  fake_agent_code=$'import sys, termios, tty, time\nfd = sys.stdin.fileno()\nold = termios.tcgetattr(fd)\nbuf = []\nready_at = time.time() + 0.5\nprint("Ready", flush=True)\nprint("  Type your message or @path/to/file", flush=True)\ntry:\n    tty.setcbreak(fd)\n    while True:\n        ch = sys.stdin.read(1)\n        if not ch:\n            break\n        if time.time() < ready_at:\n            continue\n        if ch in "\\r\\n":\n            print("* " + "".join(buf), flush=True)\n            print("London", flush=True)\n            break\n        buf.append(ch)\n        print("* " + "".join(buf), flush=True)\n        sys.stdout.flush()\nfinally:\n    termios.tcsetattr(fd, termios.TCSADRAIN, old)\n'
+
+  AGENT_TUI_PRE_PROMPT_DELAY_SECS=0.6
+  AGENT_TUI_PROMPT_SEND_MODE="slow"
+  AGENT_TUI_PROMPT_CHAR_DELAY_SECS=0
+  AGENT_TUI_PROMPT_VISIBLE_MODE="regex"
+  AGENT_TUI_PROMPT_VISIBLE_REGEX='What is the capital of England\?? Reply with only the city name\.'
+  AGENT_TUI_SUBMIT_DELAY_SECS=0
+
+  sft_tmux_start_session python3 -u -c "${fake_agent_code}"
+  sft_tmux_wait_until "Ready" 2 0.1
+  sft_tmux_assert_roundtrip
+}


### PR DESCRIPTION
## Summary
- add harness support for pre-prompt settle delays and slow character-by-character typing
- use that more conservative prompt delivery path for Gemini and Kilo on busy CI runners
- add a tmux regression test that models a TUI whose ready screen appears before it consistently accepts injected input

## Why
PR #42 initially reproduced the server-side Gemini failure again: the UI reached its ready screen, but after 60 seconds the pane was still sitting on the untouched placeholder, which points to the prompt never landing in the input buffer rather than an API latency problem. Local stress runs then reproduced the same class of failure in `kilo-code`.

The follow-up changes treat this as an input-readiness race: wait briefly after the ready screen, type more conservatively, then submit.

## Validation
- `bats tests/e2e/tmux_utils.bats`
- live-key `bats tests/e2e/gemini.bats`
- live-key `bats tests/e2e/kilo-code.bats`
- live-key `SAFEHOUSE_BATS_E2E_JOBS=3 ./tests/run.sh e2e`
