### PR TITLE
Clarify default HOME access behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ Agent Safehouse is designed around practical least privilege:
 
 It is a hardening layer, not a perfect security boundary against a determined attacker.
 
+## HOME access by default
+
+`HOME_DIR` is used to render precise home-relative rules in the assembled policy. By itself, it does not grant recursive read access to your home directory.
+
+Default Safehouse behavior is narrower:
+
+- metadata-only traversal on `/`, the path to `$HOME`, and `$HOME` itself so runtimes can probe explicitly allowed home-scoped paths
+- directory-root reads for `~/.config` and `~/.cache` so tools can discover XDG locations
+- a few explicit home-scoped files/directories from always-on profiles, such as git/ssh metadata and shared agent instruction folders
+
+In practice, `stat "$HOME"` can succeed while `ls "$HOME"` and `cat ~/secret.txt` still fail unless a more specific rule grants that path.
+
+If you want to remove even the default home exceptions, use `--append-profile`; appended profiles load last, so their deny rules can narrow earlier defaults.
+
 ## Documentation
 
 - Website: [agent-safehouse.dev](https://agent-safehouse.dev)

--- a/docs/docs/default-assumptions.md
+++ b/docs/docs/default-assumptions.md
@@ -16,6 +16,8 @@ These are baseline allowances intended to keep common workflows functional:
 - Selected workdir read/write (git root above CWD, otherwise CWD).
 - Existing linked Git worktrees for the selected repo root are granted read-only visibility when they exist at launch time.
 - Shared Git common-dir metadata for linked worktrees is granted read/write when it lives outside the selected workdir.
+- Metadata-only traversal on `/`, the path to `$HOME`, and `$HOME` itself so runtimes can reach explicitly allowed home-scoped paths without opening broad home reads.
+- Directory-root reads for `~/.config` and `~/.cache` so tools can discover XDG locations; contents under those trees still need more specific grants.
 - Core system/runtime paths required by shells, compilers, and package managers.
 - Toolchain profile access under `profiles/30-toolchains/`.
 - Curated Apple Command Line Tools shim targets for common `/usr/bin` developer commands such as `git`, `make`, and `clang`.
@@ -54,6 +56,7 @@ Enable only when required for the current task:
 
 ## Not Granted (or Explicitly Denied) by Default
 
+- Broad recursive reads of `$HOME`, directory listing of `$HOME` itself, and arbitrary file reads under `$HOME` unless a narrower explicit rule grants that path.
 - SSH private keys under `~/.ssh`.
 - SSH agent sockets (`SSH_AUTH_SOCK`, including launchd listeners and `~/.ssh/agent/*`) unless `ssh` is enabled.
 - Browser profile/cookie/session data, even when `browser-native-messaging` is enabled.

--- a/docs/docs/policy-architecture.md
+++ b/docs/docs/policy-architecture.md
@@ -48,4 +48,16 @@ Ancestor `literal` read grants are intentionally emitted for traversal compatibi
 
 Assembly logic in `/Users/eugene/server/agent-safehouse/bin/lib/policy/render.sh` replaces this with the actual absolute home path.
 
+`HOME_DIR` exists so profiles can express narrow home-relative rules through the shared helpers:
+
+- `home-literal`
+- `home-subpath`
+- `home-prefix`
+
+It is not a blanket grant for `$HOME`.
+
+Safehouse also generates a `file-read-metadata` block for `/`, the path to `$HOME`, and `$HOME` itself. That metadata-only traversal lets runtimes `stat` or walk toward explicitly allowed home-scoped paths without granting recursive reads of the whole home directory.
+
+In practice, that means `stat "$HOME"` can succeed while `ls "$HOME"` and `cat ~/secret.txt` still fail unless a more specific rule grants them.
+
 See also: [Bin Architecture](/docs/bin-architecture)

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -100,6 +100,20 @@ If your worktrees are always created under a stable folder such as `~/worktrees/
 safehouse --add-dirs-ro=~/worktrees/project-name -- codex --dangerously-bypass-approvals-and-sandbox
 ```
 
+## Default HOME Behavior
+
+Safehouse does not grant recursive `$HOME` reads by default.
+
+What it does grant by default is narrower:
+
+- metadata-only access to `/`, the path to `$HOME`, and `$HOME` itself so runtimes can probe explicitly allowed home-scoped paths
+- directory-root reads for `~/.config` and `~/.cache`
+- a few explicit home-scoped config paths from always-on profiles, such as git/ssh metadata and shared agent instruction folders
+
+So `stat "$HOME"` can succeed while `ls "$HOME"` and `cat ~/secret.txt` still fail unless another rule grants the path.
+
+If you want to tighten the default home allowances further, use `--append-profile`; appended profiles load last, so final deny rules there can narrow earlier defaults.
+
 ## Environment Modes
 
 ```bash

--- a/tests/policy/runtime/system-runtime.bats
+++ b/tests/policy/runtime/system-runtime.bats
@@ -11,6 +11,17 @@ load ../../test_helper.bash
   sft_assert_contains "$profile" "#safehouse-test-id:home-ancestor-metadata#"
 }
 
+@test "[POLICY-ONLY] generated HOME ancestor block is metadata-only and literal-scoped through HOME" { # https://github.com/eugene1g/agent-safehouse/issues/11
+  local profile home_block
+
+  profile="$(safehouse_profile)"
+  home_block="$(awk '/#safehouse-test-id:home-ancestor-metadata#/ { capture=1 } capture { print } capture && $0 == ")" { exit }' <<<"$profile")"
+
+  sft_assert_contains "$home_block" "(allow file-read-metadata"
+  sft_assert_contains "$home_block" "(literal \"$HOME\")"
+  sft_assert_not_contains "$home_block" "(subpath \"$HOME\")"
+}
+
 @test "[POLICY-ONLY] default profile includes always-on network, shared, and core integration sources" {
   local profile
 
@@ -31,6 +42,38 @@ load ../../test_helper.bash
   safehouse_ok -- /bin/ls /usr/bin
   safehouse_ok -- /bin/cat /dev/null
   safehouse_ok -- /bin/dd if=/dev/urandom bs=1 count=1
+}
+
+@test "[EXECUTION] default sandbox gets metadata on HOME itself but no general home read access" { # https://github.com/eugene1g/agent-safehouse/issues/11
+  local fake_home secret_file
+
+  fake_home="$(sft_fake_home)" || return 1
+  secret_file="${fake_home}/secret.txt"
+  printf '%s\n' "secret" > "$secret_file"
+
+  HOME="$fake_home" safehouse_ok -- /usr/bin/stat -f '%N' "$fake_home" >/dev/null
+  HOME="$fake_home" safehouse_denied -- /usr/bin/stat -f '%N' "$secret_file"
+  HOME="$fake_home" safehouse_denied -- /bin/ls "$fake_home"
+  HOME="$fake_home" safehouse_denied -- /bin/cat "$secret_file"
+}
+
+@test "[EXECUTION] default sandbox only lists the ~/.config and ~/.cache roots by default" { # https://github.com/eugene1g/agent-safehouse/issues/11
+  local fake_home config_dir cache_dir config_file cache_file
+
+  fake_home="$(sft_fake_home)" || return 1
+  config_dir="${fake_home}/.config"
+  cache_dir="${fake_home}/.cache"
+  config_file="${config_dir}/tool.conf"
+  cache_file="${cache_dir}/tool.cache"
+
+  mkdir -p "$config_dir" "$cache_dir"
+  printf '%s\n' "cfg" > "$config_file"
+  printf '%s\n' "cache" > "$cache_file"
+
+  HOME="$fake_home" safehouse_ok -- /bin/ls "$config_dir" >/dev/null
+  HOME="$fake_home" safehouse_ok -- /bin/ls "$cache_dir" >/dev/null
+  HOME="$fake_home" safehouse_denied -- /bin/cat "$config_file"
+  HOME="$fake_home" safehouse_denied -- /bin/cat "$cache_file"
 }
 
 @test "[EXECUTION] default sandbox can write to tmp" {

--- a/tests/surface/docs/documentation-consistency.bats
+++ b/tests/surface/docs/documentation-consistency.bats
@@ -34,6 +34,20 @@ load ../../test_helper.bash
   sft_assert_file_not_contains "$assumptions_path" "forbidden-exec-sugid"
 }
 
+@test "docs explain HOME_DIR as narrow home-relative access, not broad home reads" {
+  local readme_path assumptions_path architecture_path usage_path
+
+  readme_path="${SAFEHOUSE_REPO_ROOT}/README.md"
+  assumptions_path="${SAFEHOUSE_REPO_ROOT}/docs/docs/default-assumptions.md"
+  architecture_path="${SAFEHOUSE_REPO_ROOT}/docs/docs/policy-architecture.md"
+  usage_path="${SAFEHOUSE_REPO_ROOT}/docs/docs/usage.md"
+
+  sft_assert_file_contains "$readme_path" "does not grant recursive read access to your home directory"
+  sft_assert_file_contains "$assumptions_path" 'Directory-root reads for `~/.config` and `~/.cache`'
+  sft_assert_file_contains "$architecture_path" 'It is not a blanket grant for `$HOME`.'
+  sft_assert_file_contains "$usage_path" 'So `stat "$HOME"` can succeed while `ls "$HOME"` and `cat ~/secret.txt` still fail unless another rule grants the path.'
+}
+
 @test "docs feature lists cover the runtime-supported enable catalog" {
   local options_path assumptions_path
   local supported_csv raw_feature feature


### PR DESCRIPTION
## Summary
- add policy and runtime tests for the default HOME access contract
- document that `HOME_DIR` enables narrow home-relative rules and metadata-only traversal, not broad home reads
- add docs consistency coverage so that explanation does not drift

## Why
Issue #11 asked what `HOME_DIR` does and whether Safehouse allows agents to read the home directory by default. This change makes the actual behavior explicit and verifies it with tests.

## Testing
- bats tests/policy/runtime/system-runtime.bats
- bats tests/surface/docs/documentation-consistency.bats
- ./tests/run.sh -j 1

Closes #11