### PR TITLE
fix: allow bundler to read macOS system default gems

### DIFF
--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -700,6 +700,15 @@ __SAFEHOUSE_EMBEDDED_profiles_30_toolchains_python_sb__
 
 ;; Covers common Ruby managers and gem/bundler caches.
 
+;; System Ruby and Bundler enumerate the default gemspec catalog under
+;; /Library/Ruby/Gems/... even for read-only commands like `bundle --version`.
+;; Keep this read-only so the macOS-managed default gem set remains immutable.
+(allow file-read*
+    (literal "/Library")
+    (literal "/Library/Ruby")
+    (subpath "/Library/Ruby/Gems")
+)
+
 (allow file-read* file-write*
     (home-subpath "/.rbenv")
     (home-subpath "/.rvm")
@@ -8151,6 +8160,15 @@ policy_dist_append_preassembled_fixed_after_home() {
 ;; ---------------------------------------------------------------------------
 
 ;; Covers common Ruby managers and gem/bundler caches.
+
+;; System Ruby and Bundler enumerate the default gemspec catalog under
+;; /Library/Ruby/Gems/... even for read-only commands like `bundle --version`.
+;; Keep this read-only so the macOS-managed default gem set remains immutable.
+(allow file-read*
+    (literal "/Library")
+    (literal "/Library/Ruby")
+    (subpath "/Library/Ruby/Gems")
+)
 
 (allow file-read* file-write*
     (home-subpath "/.rbenv")

--- a/profiles/30-toolchains/ruby.sb
+++ b/profiles/30-toolchains/ruby.sb
@@ -6,6 +6,15 @@
 
 ;; Covers common Ruby managers and gem/bundler caches.
 
+;; System Ruby and Bundler enumerate the default gemspec catalog under
+;; /Library/Ruby/Gems/... even for read-only commands like `bundle --version`.
+;; Keep this read-only so the macOS-managed default gem set remains immutable.
+(allow file-read*
+    (literal "/Library")
+    (literal "/Library/Ruby")
+    (subpath "/Library/Ruby/Gems")
+)
+
 (allow file-read* file-write*
     (home-subpath "/.rbenv")
     (home-subpath "/.rvm")

--- a/tests/policy/runtime/toolchains.bats
+++ b/tests/policy/runtime/toolchains.bats
@@ -81,3 +81,15 @@ load ../../test_helper.bash
 
   safehouse_ok -- /bin/sh -c "cd '$SAFEHOUSE_WORKSPACE' && git init && git config user.email test@test && git config user.name test && printf x > f && git add f && git commit -m init"
 }
+
+@test "[EXECUTION] bundler can read the macOS system default gemspec catalog inside the sandbox" {
+  sft_require_cmd_or_skip bundle
+  sft_require_cmd_or_skip ruby
+
+  run /bin/sh -c 'bundle --version && ruby -e '\''require "bundler"; puts Bundler::VERSION'\'''
+  if [[ "$status" -ne 0 ]]; then
+    skip "bundler precheck failed outside sandbox"
+  fi
+
+  safehouse_ok -- /bin/sh -c 'bundle --version && ruby -e '\''require "bundler"; puts Bundler::VERSION'\'''
+}


### PR DESCRIPTION
## Summary
- allow Bundler to read the macOS system default gemspec catalog under `/Library/Ruby/Gems`
- add a runtime regression covering `bundle --version` and `require "bundler"`
- regenerate the packaged `dist/safehouse.sh` artifact

## Why
While verifying the `bundle install` repro for #54, Bundler hit a separate sandbox denial while enumerating macOS-managed default gemspecs under `/Library/Ruby/Gems/.../specifications/default`. This change fixes that follow-up issue with a narrow read-only grant.

## Testing
- `./scripts/generate-dist.sh`
- `bats tests/policy/runtime/toolchains.bats tests/surface/packaging/dist-parity.bats tests/surface/packaging/generate-dist.bats`
- `./tests/run.sh`
- `./bin/safehouse.sh -- bundle --version`
- repro: `bundle install --verbose` in a temp dir with `BUNDLE_PATH=vendor/bundle`

Refs #54