### PR TITLE
fix: ignore stale git worktree metadata on startup

### DIFF
--- a/bin/lib/support/git-discovery.sh
+++ b/bin/lib/support/git-discovery.sh
@@ -254,20 +254,21 @@ safehouse_emit_git_worktree_paths_from_filesystem() {
 
   for entry_dir in "${common_dir}/worktrees"/*; do
     [[ -d "$entry_dir" ]] || continue
-    [[ -f "${entry_dir}/gitdir" ]] || return 1
+    [[ -f "${entry_dir}/gitdir" ]] || continue
 
     IFS= read -r gitdir_path < "${entry_dir}/gitdir" || true
-    [[ -n "$gitdir_path" ]] || return 1
+    [[ -n "$gitdir_path" ]] || continue
 
     if [[ "$gitdir_path" == /* ]]; then
-      gitdir_path="$(safehouse_normalize_abs_path "$gitdir_path")" || return 1
+      [[ -e "$gitdir_path" ]] || continue
     else
-      gitdir_path="$(safehouse_git_resolve_path_from_base_dir "$entry_dir" "$gitdir_path" || true)"
-      [[ -n "$gitdir_path" ]] || return 1
+      gitdir_path="${entry_dir%/}/${gitdir_path}"
+      [[ -e "$gitdir_path" ]] || continue
     fi
 
+    gitdir_path="$(safehouse_normalize_abs_path "$gitdir_path")" || return 1
     worktree_path="${gitdir_path%/*}"
-    [[ -n "$worktree_path" && -d "$worktree_path" ]] || return 1
+    [[ -n "$worktree_path" && -d "$worktree_path" ]] || continue
 
     normalized_path="$(safehouse_normalize_abs_path "$worktree_path")" || return 1
     printf '%s\n' "$normalized_path"

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -3273,20 +3273,21 @@ safehouse_emit_git_worktree_paths_from_filesystem() {
 
   for entry_dir in "${common_dir}/worktrees"/*; do
     [[ -d "$entry_dir" ]] || continue
-    [[ -f "${entry_dir}/gitdir" ]] || return 1
+    [[ -f "${entry_dir}/gitdir" ]] || continue
 
     IFS= read -r gitdir_path < "${entry_dir}/gitdir" || true
-    [[ -n "$gitdir_path" ]] || return 1
+    [[ -n "$gitdir_path" ]] || continue
 
     if [[ "$gitdir_path" == /* ]]; then
-      gitdir_path="$(safehouse_normalize_abs_path "$gitdir_path")" || return 1
+      [[ -e "$gitdir_path" ]] || continue
     else
-      gitdir_path="$(safehouse_git_resolve_path_from_base_dir "$entry_dir" "$gitdir_path" || true)"
-      [[ -n "$gitdir_path" ]] || return 1
+      gitdir_path="${entry_dir%/}/${gitdir_path}"
+      [[ -e "$gitdir_path" ]] || continue
     fi
 
+    gitdir_path="$(safehouse_normalize_abs_path "$gitdir_path")" || return 1
     worktree_path="${gitdir_path%/*}"
-    [[ -n "$worktree_path" && -d "$worktree_path" ]] || return 1
+    [[ -n "$worktree_path" && -d "$worktree_path" ]] || continue
 
     normalized_path="$(safehouse_normalize_abs_path "$worktree_path")" || return 1
     printf '%s\n' "$normalized_path"

--- a/tests/surface/cli/explain.bats
+++ b/tests/surface/cli/explain.bats
@@ -65,3 +65,31 @@ load ../../test_helper.bash
   sft_assert_file_contains "$explain_log" "git worktree common dir grant: ${git_common_dir}"
   sft_assert_file_contains "$explain_log" "git linked worktree read grants: ${repo_root} ${sibling_worktree}"
 }
+
+@test "--explain skips stale linked worktree admin entries without surfacing realpath errors" {
+  local explain_log repo_root worktree_parent stale_worktree sibling_worktree
+
+  sft_require_cmd_or_skip git
+
+  explain_log="$(sft_workspace_path "explain-stale-worktree.log")"
+  repo_root="$(sft_external_dir "explain-stale-git-worktree")" || return 1
+  worktree_parent="$(dirname "$repo_root")"
+  stale_worktree="${worktree_parent}/stale-worktree"
+  sibling_worktree="${worktree_parent}/review-worktree"
+
+  git -C "$repo_root" init -q || return 1
+  printf '%s\n' "tracked" > "${repo_root}/tracked.txt"
+  git -C "$repo_root" add tracked.txt || return 1
+  git -C "$repo_root" -c user.name=test -c user.email=test@example.com commit -q -m init || return 1
+  git -C "$repo_root" branch stale || return 1
+  git -C "$repo_root" branch review || return 1
+  git -C "$repo_root" worktree add -q "$stale_worktree" stale || return 1
+  git -C "$repo_root" worktree add -q "$sibling_worktree" review || return 1
+  rm -rf "$stale_worktree" || return 1
+
+  safehouse_ok_in_dir "$repo_root" --explain --stdout >/dev/null 2>"$explain_log"
+
+  sft_assert_file_not_contains "$explain_log" "realpath:"
+  sft_assert_file_contains "$explain_log" "git linked worktree read grants: ${sibling_worktree}"
+  sft_assert_file_not_contains "$explain_log" "$stale_worktree"
+}


### PR DESCRIPTION
## Why
Safehouse snapshots sibling Git worktrees at launch to grant read access across existing worktrees. When a repo still has a prunable worktree admin entry, the filesystem fast path tried to `realpath` the deleted worktree's top-level `.git` marker and surfaced a noisy error like:

```
realpath: /private/tmp/platform-ci-debug/.git: No such file or directory
```

That warning came from Safehouse startup, not from the launched agent.

## What changed
- skip stale `.git/worktrees/*/gitdir` entries whose recorded marker path no longer exists
- keep valid sibling worktree grants intact instead of failing the whole discovery pass noisily
- add a surface regression covering a deleted linked worktree alongside a surviving sibling
- regenerate `dist/safehouse.sh`

## Validation
- `bats tests/surface/cli/explain.bats`
- `bats tests/policy/workdir/workdir-selection.bats`
- direct repro with a deleted linked worktree against `dist/safehouse.sh`, confirming no `realpath:` output
