### PR TITLE
chromium-headless: add branded Google Chrome support

### DIFF
--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -1239,7 +1239,7 @@ __SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_chromium_full_sb__
 ;; ---------------------------------------------------------------------------
 ;; Integration: Chromium Headless
 ;; AppKit, crashpad, GPU, and launch-service allowances needed by headless
-;; Chromium/Playwright runtimes under Safehouse.
+;; Chromium/Playwright runtimes and branded Google Chrome under Safehouse.
 ;; Source: 55-integrations-optional/chromium-headless.sb
 ;; #safehouse-test-id:chromium-headless-integration#
 ;; #safehouse-test-id:chromium-headless-gpu#
@@ -1276,6 +1276,7 @@ __SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_chromium_full_sb__
     (literal "/Library/Preferences/com.apple.HIToolbox.plist")
     (home-subpath "/Library/Preferences/com.apple.LaunchServices")
     (home-subpath "/Library/Application Support/CrashReporter")
+    (home-subpath "/Library/Application Support/Google/Chrome/Crashpad")  ;; Branded Google Chrome crashpad database
     (home-subpath "/Library/Spelling")
     (home-literal "/Library/Keyboard Layouts")
     (home-literal "/Library/Input Methods")
@@ -1288,6 +1289,8 @@ __SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_chromium_full_sb__
 (allow mach-register
     (global-name-regex #"^org\.chromium\.Chromium\.MachPortRendezvousServer\.")
     (global-name-regex #"^org\.chromium\.crashpad\.child_port_handshake\.")
+    (global-name-regex #"^com\.google\.Chrome\.MachPortRendezvousServer\.")     ;; Branded Google Chrome uses com.google.Chrome.* instead of org.chromium.Chromium.*
+    (global-name-regex #"^com\.google\.Chrome\.crashpad\.child_port_handshake\.") ;; Branded Google Chrome crashpad handshake
     (local-name "com.apple.axserver")
     (local-name "com.apple.tsm.portname")
     (local-name "com.apple.coredrag")
@@ -1296,6 +1299,8 @@ __SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_chromium_full_sb__
 (allow mach-lookup
     (global-name-regex #"^org\.chromium\.Chromium\.MachPortRendezvousServer\.")
     (global-name-regex #"^org\.chromium\.crashpad\.child_port_handshake\.")
+    (global-name-regex #"^com\.google\.Chrome\.MachPortRendezvousServer\.")     ;; Branded Google Chrome
+    (global-name-regex #"^com\.google\.Chrome\.crashpad\.child_port_handshake\.") ;; Branded Google Chrome crashpad
     (global-name "com.apple.MTLCompilerService")
     (global-name "com.apple.SafariPlatformSupport.Helper")
     (global-name "com.apple.CARenderServer")
@@ -1346,6 +1351,16 @@ __SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_chromium_full_sb__
     (global-name "com.apple.naturallanguaged")
     (global-name "com.apple.inputanalyticsd")
     (global-name-prefix "com.apple.distributed_notifications@")
+)
+
+;; Branded Google Chrome crashpad database initialization requires xattr and write access.
+;; Chromium/Playwright typically uses a temp-dir profile that lands under /tmp (already allowed).
+;; Google Chrome defaults to ~/Library/Application Support/Google/Chrome/Crashpad.
+(allow file-read* file-write*
+    (home-subpath "/Library/Application Support/Google/Chrome/Crashpad")
+)
+(allow file-read-xattr file-write-xattr
+    (home-subpath "/Library/Application Support/Google/Chrome/Crashpad")
 )
 
 (allow system-fsctl

--- a/profiles/55-integrations-optional/chromium-headless.sb
+++ b/profiles/55-integrations-optional/chromium-headless.sb
@@ -1,7 +1,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Integration: Chromium Headless
 ;; AppKit, crashpad, GPU, and launch-service allowances needed by headless
-;; Chromium/Playwright runtimes under Safehouse.
+;; Chromium/Playwright runtimes and branded Google Chrome under Safehouse.
 ;; Source: 55-integrations-optional/chromium-headless.sb
 ;; #safehouse-test-id:chromium-headless-integration#
 ;; #safehouse-test-id:chromium-headless-gpu#
@@ -38,6 +38,7 @@
     (literal "/Library/Preferences/com.apple.HIToolbox.plist")
     (home-subpath "/Library/Preferences/com.apple.LaunchServices")
     (home-subpath "/Library/Application Support/CrashReporter")
+    (home-subpath "/Library/Application Support/Google/Chrome/Crashpad")  ;; Branded Google Chrome crashpad database
     (home-subpath "/Library/Spelling")
     (home-literal "/Library/Keyboard Layouts")
     (home-literal "/Library/Input Methods")
@@ -50,6 +51,8 @@
 (allow mach-register
     (global-name-regex #"^org\.chromium\.Chromium\.MachPortRendezvousServer\.")
     (global-name-regex #"^org\.chromium\.crashpad\.child_port_handshake\.")
+    (global-name-regex #"^com\.google\.Chrome\.MachPortRendezvousServer\.")     ;; Branded Google Chrome uses com.google.Chrome.* instead of org.chromium.Chromium.*
+    (global-name-regex #"^com\.google\.Chrome\.crashpad\.child_port_handshake\.") ;; Branded Google Chrome crashpad handshake
     (local-name "com.apple.axserver")
     (local-name "com.apple.tsm.portname")
     (local-name "com.apple.coredrag")
@@ -58,6 +61,8 @@
 (allow mach-lookup
     (global-name-regex #"^org\.chromium\.Chromium\.MachPortRendezvousServer\.")
     (global-name-regex #"^org\.chromium\.crashpad\.child_port_handshake\.")
+    (global-name-regex #"^com\.google\.Chrome\.MachPortRendezvousServer\.")     ;; Branded Google Chrome
+    (global-name-regex #"^com\.google\.Chrome\.crashpad\.child_port_handshake\.") ;; Branded Google Chrome crashpad
     (global-name "com.apple.MTLCompilerService")
     (global-name "com.apple.SafariPlatformSupport.Helper")
     (global-name "com.apple.CARenderServer")
@@ -108,6 +113,16 @@
     (global-name "com.apple.naturallanguaged")
     (global-name "com.apple.inputanalyticsd")
     (global-name-prefix "com.apple.distributed_notifications@")
+)
+
+;; Branded Google Chrome crashpad database initialization requires xattr and write access.
+;; Chromium/Playwright typically uses a temp-dir profile that lands under /tmp (already allowed).
+;; Google Chrome defaults to ~/Library/Application Support/Google/Chrome/Crashpad.
+(allow file-read* file-write*
+    (home-subpath "/Library/Application Support/Google/Chrome/Crashpad")
+)
+(allow file-read-xattr file-write-xattr
+    (home-subpath "/Library/Application Support/Google/Chrome/Crashpad")
 )
 
 (allow system-fsctl


### PR DESCRIPTION
## Problem

The `chromium-headless` integration only matches `org.chromium.Chromium.*` Mach port names, which works for Chromium and Playwright-managed browsers but not for branded Google Chrome (`brew install --cask google-chrome` or direct download).

Google Chrome registers Mach services under `com.google.Chrome.*` instead:
- `com.google.Chrome.MachPortRendezvousServer.<pid>`
- `com.google.Chrome.crashpad.child_port_handshake.<pid>`

Without these patterns, headless Chrome crashes immediately on launch:

```
FATAL:base/apple/mach_port_rendezvous_mac.cc:159
Check failed: kr == KERN_SUCCESS.
bootstrap_check_in com.google.Chrome.MachPortRendezvousServer.59910: Permission denied (1100)
```

Chrome's crashpad also needs xattr access to initialize its database at `~/Library/Application Support/Google/Chrome/Crashpad`, which fails with `Operation not permitted` under the current policy.

## Changes

- Added `com.google.Chrome.MachPortRendezvousServer.*` and `com.google.Chrome.crashpad.child_port_handshake.*` regex patterns to both `mach-register` and `mach-lookup` rules
- Added `file-read*`, `file-write*`, `file-read-xattr`, and `file-write-xattr` grants for `~/Library/Application Support/Google/Chrome/Crashpad`
- Regenerated `dist/`

## Security impact

Narrow additions - only the branded Chrome Mach port namespace and its crashpad database directory. No broader grants. Consistent with the existing Chromium patterns already in the profile.

## Testing

Discovered and validated while running Lighthouse (`npx lighthouse https://koi.eco --chrome-flags="--headless=new"`) from a sandboxed [Pi](https://github.com/mariozechner/pi-coding-agent) agent session. Before the fix, Chrome crashed on Mach port registration. After the fix, Lighthouse completes successfully and produces reports.

Could not run `./tests/run.sh` from within the sandbox. Static validation: the added rules follow the same pattern as the existing `org.chromium.*` rules.