### PR TITLE
Allow explicit keychain enablement for plugin-backed OpenCode auth

### DIFF
--- a/bin/lib/policy/constants.sh
+++ b/bin/lib/policy/constants.sh
@@ -68,10 +68,7 @@ policy_optional_integration_feature_basename_from_profile_key() {
 
 policy_optional_integration_feature_is_user_exposed() {
   local feature="$1"
-  local hidden_feature=""
-
-  hidden_feature="$(basename "${policy_keychain_requirement_token}" .sb)"
-  [[ "$feature" != "$hidden_feature" ]]
+  [[ -n "$feature" ]]
 }
 
 policy_build_supported_enable_features_csv() {

--- a/bin/lib/policy/plan.sh
+++ b/bin/lib/policy/plan.sh
@@ -376,7 +376,7 @@ policy_plan_finalize_optional_integrations() {
     policy_plan_optional_integrations_not_included+=("$feature")
   done
 
-  if policy_plan_optional_profile_required_by_selected_profiles "profiles/${policy_keychain_requirement_token}" || policy_plan_optional_profile_required_by_enabled_optional_profiles "profiles/${policy_keychain_requirement_token}"; then
+  if policy_plan_optional_profile_selected "profiles/${policy_keychain_requirement_token}" || policy_plan_optional_profile_required_by_selected_profiles "profiles/${policy_keychain_requirement_token}" || policy_plan_optional_profile_required_by_enabled_optional_profiles "profiles/${policy_keychain_requirement_token}"; then
     policy_plan_keychain_included=1
     policy_plan_append_optional_profile_key "profiles/${policy_keychain_requirement_token}" || true
   fi

--- a/bin/lib/policy/render.sh
+++ b/bin/lib/policy/render.sh
@@ -379,7 +379,7 @@ policy_render_emit_integration_preamble() {
   else
     policy_render_write_line ";; Optional integrations not included: $(safehouse_join_by_space)"
   fi
-  policy_render_write_line ";; Keychain integration (auto-injected from profile requirements): ${keychain_status}"
+  policy_render_write_line ";; Keychain integration (explicitly enabled or auto-injected from profile requirements): ${keychain_status}"
   policy_render_write_line ";; Use --enable=<feature> (comma-separated) to include optional integrations explicitly."
   policy_render_write_line ";; Note: selected profiles and enabled optional integrations can inject dependencies via \$\$require=<profile-path>\$\$ metadata."
   policy_render_write_line ";; Threat-model note: blocking exfiltration/C2 is explicitly NOT a goal for this sandbox."

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -1526,7 +1526,8 @@ __SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_electron_sb__
 ;; Source: 55-integrations-optional/keychain.sb
 ;; ---------------------------------------------------------------------------
 
-;; Auto-injected when a selected app/agent profile declares Keychain as a dependency.
+;; Can be explicitly enabled with --enable=keychain, and is also auto-injected
+;; when a selected app/agent profile declares Keychain as a dependency.
 
 (allow file-read* file-write*
     (home-subpath "/Library/Keychains")                        ;; Keychain DB/files for CLI login sessions using macOS credentials.
@@ -3591,10 +3592,7 @@ policy_optional_integration_feature_basename_from_profile_key() {
 
 policy_optional_integration_feature_is_user_exposed() {
   local feature="$1"
-  local hidden_feature=""
-
-  hidden_feature="$(basename "${policy_keychain_requirement_token}" .sb)"
-  [[ "$feature" != "$hidden_feature" ]]
+  [[ -n "$feature" ]]
 }
 
 policy_build_supported_enable_features_csv() {
@@ -5013,7 +5011,7 @@ policy_plan_finalize_optional_integrations() {
     policy_plan_optional_integrations_not_included+=("$feature")
   done
 
-  if policy_plan_optional_profile_required_by_selected_profiles "profiles/${policy_keychain_requirement_token}" || policy_plan_optional_profile_required_by_enabled_optional_profiles "profiles/${policy_keychain_requirement_token}"; then
+  if policy_plan_optional_profile_selected "profiles/${policy_keychain_requirement_token}" || policy_plan_optional_profile_required_by_selected_profiles "profiles/${policy_keychain_requirement_token}" || policy_plan_optional_profile_required_by_enabled_optional_profiles "profiles/${policy_keychain_requirement_token}"; then
     policy_plan_keychain_included=1
     policy_plan_append_optional_profile_key "profiles/${policy_keychain_requirement_token}" || true
   fi
@@ -5476,7 +5474,7 @@ policy_render_emit_integration_preamble() {
   else
     policy_render_write_line ";; Optional integrations not included: $(safehouse_join_by_space)"
   fi
-  policy_render_write_line ";; Keychain integration (auto-injected from profile requirements): ${keychain_status}"
+  policy_render_write_line ";; Keychain integration (explicitly enabled or auto-injected from profile requirements): ${keychain_status}"
   policy_render_write_line ";; Use --enable=<feature> (comma-separated) to include optional integrations explicitly."
   policy_render_write_line ";; Note: selected profiles and enabled optional integrations can inject dependencies via \$\$require=<profile-path>\$\$ metadata."
   policy_render_write_line ";; Threat-model note: blocking exfiltration/C2 is explicitly NOT a goal for this sandbox."
@@ -8050,6 +8048,7 @@ policy_embedded_optional_integration_features=(
   "cloud-credentials"
   "docker"
   "electron"
+  "keychain"
   "kubectl"
   "lldb"
   "macos-gui"
@@ -8092,7 +8091,7 @@ policy_dist_preassembled_core_integration_keys=(
   "profiles/50-integrations-core/ssh-agent-default-deny.sb"
 )
 
-policy_embedded_supported_enable_features="1password, agent-browser, browser-native-messaging, chromium-full, chromium-headless, cleanshot, clipboard, cloud-credentials, docker, electron, kubectl, lldb, macos-gui, microphone, playwright-chrome, process-control, shell-init, spotlight, ssh, vscode, xcode, all-agents, all-apps, wide-read"
+policy_embedded_supported_enable_features="1password, agent-browser, browser-native-messaging, chromium-full, chromium-headless, cleanshot, clipboard, cloud-credentials, docker, electron, keychain, kubectl, lldb, macos-gui, microphone, playwright-chrome, process-control, shell-init, spotlight, ssh, vscode, xcode, all-agents, all-apps, wide-read"
 
 policy_dist_emit_embedded_profile_requirement_tokens() {
   case "$1" in

--- a/docs/docs/agent-investigations/opencode.md
+++ b/docs/docs/agent-investigations/opencode.md
@@ -72,7 +72,7 @@ In this mode, it bypasses the TUI entirely and runs a spinner to stdout.
 
 ### 3.1 Credential Storage
 
-OpenCode does **NOT** use macOS Keychain, `go-keyring`, or any OS-level credential storage. It does **NOT** use OAuth flows. All authentication is via environment variables and config files.
+Core OpenCode does **NOT** use macOS Keychain, `go-keyring`, or any OS-level credential storage. It does **NOT** use OAuth flows. Its built-in authentication is via environment variables and config files. Plugin-based auth providers can still add keychain-dependent behavior on top.
 
 ### 3.2 API Key Sources and Priority Order
 
@@ -674,6 +674,6 @@ Based on this analysis, a sandbox for OpenCode should:
 
 5. **No port binding** is needed (OpenCode does not listen on any ports)
 
-6. **No keychain/keyring** access needed
+6. **No keychain/keyring** access is needed for core OpenCode itself, but plugin-based auth providers may require explicit `--enable=keychain` and any additional helper-CLI grants they shell out to
 
 7. **No browser launching** by OpenCode directly (indirect dependency only from Azure SDK)

--- a/docs/docs/default-assumptions.md
+++ b/docs/docs/default-assumptions.md
@@ -40,6 +40,7 @@ Enable only when required for the current task:
 - `chromium-full`: system Google Chrome and related full Chrome allowances.
 - `docker`: Docker socket and related access.
 - `1password`: 1Password CLI/app integration paths.
+- `keychain`: macOS Keychain and `security`-tool access for credential-backed helper or plugin flows that need explicit opt-in.
 - `kubectl`: kube config/cache + krew state.
 - `shell-init`: shell startup/config file reads.
 - `ssh`: extended SSH agent socket and system SSH config integration.

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -23,6 +23,7 @@
 - `clipboard`
 - `docker`
 - `kubectl`
+- `keychain`
 - `macos-gui`
 - `microphone`
 - `electron` (implies `macos-gui`)
@@ -45,6 +46,8 @@
 - `wide-read`
 
 Common Apple shimmed developer tools such as `/usr/bin/git`, `/usr/bin/make`, and `/usr/bin/clang` are available by default via `profiles/30-toolchains/apple-toolchain-core.sb`; this is not an optional `--enable` feature.
+
+`keychain` is mainly for plugin or helper flows that need macOS credential access but are not auto-detected by a built-in Safehouse profile. For example, core `opencode` does not require keychain access, but plugin-based auth flows such as `opencode-claude-auth` can opt in with `--enable=keychain`.
 
 `vscode` is explicit cold-start editor integration for Visual Studio Code. For Claude's external-editor handoff:
 

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -27,7 +27,7 @@ Each policy rule should answer one question:
 - LLDB/debugger toolchain access only when `--enable=lldb` is selected.
 - Xcode developer roots and per-user build/simulator state only when `--enable=xcode` is selected.
 - Agent/app-specific config grants scoped to the wrapped command.
-- Keychain/security integration when selected profiles declare keychain dependency metadata.
+- Keychain/security integration when `--enable=keychain` is selected or selected profiles declare keychain dependency metadata.
 - Core SCM integration profiles and related defaults for tools such as `git`, `gh`, and `glab`.
 - Sanitized runtime environment by default, with explicit opt-in controls for env pass-through and `SDKROOT` preserved when set.
 - Network access by default for registries, APIs, remotes, and MCP servers.

--- a/profiles/55-integrations-optional/keychain.sb
+++ b/profiles/55-integrations-optional/keychain.sb
@@ -4,7 +4,8 @@
 ;; Source: 55-integrations-optional/keychain.sb
 ;; ---------------------------------------------------------------------------
 
-;; Auto-injected when a selected app/agent profile declares Keychain as a dependency.
+;; Can be explicitly enabled with --enable=keychain, and is also auto-injected
+;; when a selected app/agent profile declares Keychain as a dependency.
 
 (allow file-read* file-write*
     (home-subpath "/Library/Keychains")                        ;; Keychain DB/files for CLI login sessions using macOS credentials.

--- a/scripts/generate-dist.sh
+++ b/scripts/generate-dist.sh
@@ -22,7 +22,6 @@ embedded_supported_enable_synthetic_features=(
   all-apps
   wide-read
 )
-embedded_hidden_optional_integration_feature="keychain"
 generator_metadata_helpers_loaded=0
 dist_preassembled_fixed_before_home_keys=()
 dist_preassembled_fixed_after_home_keys=()
@@ -238,9 +237,6 @@ collect_embedded_feature_catalog() {
 
   for rel_path in "${profile_files[@]}"; do
     feature="$(optional_integration_feature_from_profile_path "$rel_path")" || continue
-    if [[ "$feature" == "$embedded_hidden_optional_integration_feature" ]]; then
-      continue
-    fi
     embedded_optional_integration_features+=("$feature")
   done
 

--- a/tests/policy/integrations/keychain.bats
+++ b/tests/policy/integrations/keychain.bats
@@ -15,6 +15,19 @@ load ../../test_helper.bash
   sft_assert_omits_source "$aider_profile" "55-integrations-optional/keychain.sb"
 }
 
+@test "[POLICY-ONLY] --enable=keychain explicitly includes keychain integration for opencode" {
+  local fake_home fake_opencode profile
+
+  fake_home="$(sft_fake_home)" || return 1
+  fake_opencode="${fake_home}/.local/bin/opencode"
+  sft_make_fake_command "$fake_opencode"
+
+  profile="$(HOME="$fake_home" safehouse_profile --enable=keychain -- "$fake_opencode")"
+
+  sft_assert_includes_source "$profile" "60-agents/opencode.sb"
+  sft_assert_includes_source "$profile" "55-integrations-optional/keychain.sb"
+}
+
 @test "[EXECUTION] security tool is denied by default but allowed for a keychain-enabled agent profile" {
   local keychain_policy non_keychain_policy
 

--- a/tests/surface/cli/enable-parsing.bats
+++ b/tests/surface/cli/enable-parsing.bats
@@ -4,13 +4,15 @@
 load ../../test_helper.bash
 
 @test "[POLICY-ONLY] separate-form --enable parses representative optional integrations" {
-  local docker_profile shell_init_profile xcode_profile
+  local docker_profile keychain_profile shell_init_profile xcode_profile
 
   docker_profile="$(safehouse_profile --enable docker)"
+  keychain_profile="$(safehouse_profile --enable keychain)"
   shell_init_profile="$(safehouse_profile --enable shell-init)"
   xcode_profile="$(safehouse_profile --enable xcode)"
 
   sft_assert_includes_source "$docker_profile" "55-integrations-optional/docker.sb"
+  sft_assert_includes_source "$keychain_profile" "55-integrations-optional/keychain.sb"
   sft_assert_includes_source "$shell_init_profile" "55-integrations-optional/shell-init.sb"
   sft_assert_includes_source "$xcode_profile" "55-integrations-optional/xcode.sb"
   sft_assert_omits_source "$xcode_profile" "55-integrations-optional/lldb.sb"

--- a/tests/surface/cli/explain.bats
+++ b/tests/surface/cli/explain.bats
@@ -39,6 +39,17 @@ load ../../test_helper.bash
   sft_assert_file_contains "$profile_log" "profile env defaults: PLAYWRIGHT_MCP_SANDBOX=false"
 }
 
+@test "--explain reports explicitly enabled keychain integration as included" {
+  local explain_log
+
+  explain_log="$(sft_workspace_path "explain-keychain.log")"
+
+  safehouse_ok --enable=keychain --explain --stdout -- /usr/bin/true >/dev/null 2>"$explain_log"
+
+  sft_assert_file_contains "$explain_log" "optional integrations explicitly enabled: keychain"
+  sft_assert_file_contains "$explain_log" "keychain integration: included"
+}
+
 @test "--explain reports command resolution details and debug hints" {
   local explain_log fake_cmd fake_cmd_name
 

--- a/tests/surface/packaging/generate-dist.bats
+++ b/tests/surface/packaging/generate-dist.bats
@@ -79,6 +79,11 @@ rewrite_file_with_sed() {
   sft_assert_file_contains "$custom_dist" "SAFEHOUSE_SELF_UPDATE_VALIDATION_MARKER=standalone-release-asset-v1"
   sft_assert_file_not_contains "$custom_dist" "apple-build-tools"
   sft_assert_file_not_contains "$custom_dist" "SAFEHOUSE_CLAUDE_POLICY_URL"
+
+  run "$custom_dist" --stdout --enable=keychain -- /usr/bin/true
+
+  [ "$status" -eq 0 ]
+  sft_assert_contains "$output" "$(sft_source_marker "55-integrations-optional/keychain.sb")"
 }
 
 @test "generate-dist.sh supports --output-dir without recreating deprecated dist artifacts" {


### PR DESCRIPTION
Closes #71

## Why
`keychain` already existed as an optional integration, but it was hidden from the user-facing `--enable` catalog. That meant `--enable=keychain` failed even though plugin-backed OpenCode auth flows like `opencode-claude-auth` need it to read Claude credentials from the macOS Keychain.

## What changed
- expose `keychain` as an explicit `--enable` feature in both source and generated dist catalogs
- keep core `opencode` least-privilege defaults unchanged while allowing plugin flows to opt in
- fix `--explain` / policy preamble bookkeeping so explicit keychain enablement reports as included
- update docs and add regression coverage for parse, policy, explain, and dist generation paths

## Verification
- `./tests/run.sh`
- `bats tests/policy/integrations/keychain.bats`
- `bats tests/surface/cli/enable-parsing.bats tests/surface/cli/explain.bats`
- `bats tests/surface/packaging/generate-dist.bats`