### PR TITLE
feat: add terminal deny rules to protect .safehouse from agent writes

### DIFF
--- a/bin/lib/cli/output.sh
+++ b/bin/lib/cli/output.sh
@@ -99,6 +99,14 @@ Policy scope options:
   --trust-workdir-config=BOOL
       Trust and load <workdir>/.safehouse (default: disabled)
 
+  --allow-workdir-config-writes
+      Skip the terminal deny-write rule for .safehouse config files.
+      By default, Safehouse always emits a deny file-write* rule for any
+      .safehouse file as the very last rule in the policy, ensuring agents
+      cannot modify workdir config regardless of path grants. Use this flag
+      only if you intentionally want the sandboxed process to be able to
+      write to .safehouse files.
+
   --append-profile PATH
   --append-profile=PATH
       Append an additional sandbox profile file after generated rules

--- a/bin/lib/cli/parse.sh
+++ b/bin/lib/cli/parse.sh
@@ -19,6 +19,7 @@ cli_policy_workdir_set=0
 cli_policy_workdir_value=""
 cli_policy_trust_workdir_config_set=0
 cli_policy_trust_workdir_config_value=0
+cli_policy_allow_workdir_config_writes=0
 cli_policy_append_profiles=()
 cli_policy_output_path=""
 cli_policy_output_path_set=0
@@ -46,6 +47,7 @@ cli_parse_reset() {
   cli_policy_workdir_value=""
   cli_policy_trust_workdir_config_set=0
   cli_policy_trust_workdir_config_value=0
+  cli_policy_allow_workdir_config_writes=0
   cli_policy_append_profiles=()
   cli_policy_output_path=""
   cli_policy_output_path_set=0
@@ -309,6 +311,11 @@ cli_parse_policy_flag_option() {
         return 1
       fi
       cli_policy_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --allow-workdir-config-writes)
+      cli_policy_allow_workdir_config_writes=1
       cli_parse_consumed_args=1
       return 0
       ;;

--- a/bin/lib/policy/explain.sh
+++ b/bin/lib/policy/explain.sh
@@ -229,6 +229,7 @@ policy_explain_print_summary() {
         echo "  selected scoped profile: ${profile} (${reason})"
       done
     fi
+    echo "  allow workdir config writes: $([[ "$policy_req_allow_workdir_config_writes" -eq 1 ]] && echo "enabled" || echo "disabled (default)")"
     echo "  sandbox denial log hint: /usr/bin/log show --last 2m --style compact --predicate 'eventMessage CONTAINS \"Sandbox:\" AND eventMessage CONTAINS \"deny(\"'"
   } >&2
 }

--- a/bin/lib/policy/render.sh
+++ b/bin/lib/policy/render.sh
@@ -715,11 +715,26 @@ policy_render_emit_scoped_sections() {
   policy_render_append_scoped_module_dir "profiles/65-apps" || return 1
 }
 
+# Emit terminal deny rules that must survive all path grants.
+# These are always last so no (allow file-write* (subpath …)) from workdir,
+# extra-access-rules, wide-read, or appended profiles can override them.
+policy_render_emit_terminal_deny_rules() {
+  # Keep safehouse configs safe
+  if [[ "$policy_req_allow_workdir_config_writes" -eq 1 ]]; then
+    return 0
+  fi
+  policy_render_write_line ";; #safehouse-test-id:terminal-deny-safehouse# Terminal deny rules are emitted last so they override any earlier path grants."
+  policy_render_write_line ";; Agents must never modify Safehouse config files regardless of workdir grants."
+  policy_render_write_line "(deny file-write* (regex #\"/\\.safehouse\$\"))"
+  policy_render_write_blank
+}
+
 policy_render_emit_dynamic_sections() {
   policy_render_emit_extra_access_rules || return 1
   policy_render_emit_wide_read_access
   policy_render_emit_workdir_access "$policy_req_effective_workdir" || return 1
   policy_render_append_cli_profiles || return 1
+  policy_render_emit_terminal_deny_rules || return 1
 }
 
 policy_render_emit_all_sections() {

--- a/bin/lib/policy/request.sh
+++ b/bin/lib/policy/request.sh
@@ -29,6 +29,7 @@ policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
 policy_req_workdir_config_ignored_untrusted=0
+policy_req_allow_workdir_config_writes=0
 policy_req_invoked_command_path=""
 policy_req_invoked_command_basename=""
 policy_req_invoked_command_profile_path=""
@@ -166,6 +167,7 @@ policy_request_reset() {
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
   policy_req_workdir_config_ignored_untrusted=0
+  policy_req_allow_workdir_config_writes=0
   policy_req_invoked_command_path=""
   policy_req_invoked_command_basename=""
   policy_req_invoked_command_profile_path=""
@@ -425,6 +427,10 @@ policy_request_load_effective_workdir_config() {
   fi
 }
 
+policy_request_resolve_allow_workdir_config_writes() {
+  policy_req_allow_workdir_config_writes="$cli_policy_allow_workdir_config_writes"
+}
+
 policy_request_merge_add_dir_inputs() {
   local config_ro_name="$1"
   local env_ro_name="$2"
@@ -484,6 +490,7 @@ policy_request_build() {
   policy_request_resolve_git_linked_worktree_access || return 1
   policy_request_resolve_append_profile_paths || return 1
   policy_request_load_effective_workdir_config config_add_dirs_ro_inputs config_add_dirs_rw_inputs || return 1
+  policy_request_resolve_allow_workdir_config_writes
   policy_request_merge_add_dir_inputs \
     config_add_dirs_ro_inputs \
     env_add_dirs_ro_inputs \

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -4151,6 +4151,7 @@ policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
 policy_req_workdir_config_ignored_untrusted=0
+policy_req_allow_workdir_config_writes=0
 policy_req_invoked_command_path=""
 policy_req_invoked_command_basename=""
 policy_req_invoked_command_profile_path=""
@@ -4288,6 +4289,7 @@ policy_request_reset() {
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
   policy_req_workdir_config_ignored_untrusted=0
+  policy_req_allow_workdir_config_writes=0
   policy_req_invoked_command_path=""
   policy_req_invoked_command_basename=""
   policy_req_invoked_command_profile_path=""
@@ -4547,6 +4549,10 @@ policy_request_load_effective_workdir_config() {
   fi
 }
 
+policy_request_resolve_allow_workdir_config_writes() {
+  policy_req_allow_workdir_config_writes="$cli_policy_allow_workdir_config_writes"
+}
+
 policy_request_merge_add_dir_inputs() {
   local config_ro_name="$1"
   local env_ro_name="$2"
@@ -4606,6 +4612,7 @@ policy_request_build() {
   policy_request_resolve_git_linked_worktree_access || return 1
   policy_request_resolve_append_profile_paths || return 1
   policy_request_load_effective_workdir_config config_add_dirs_ro_inputs config_add_dirs_rw_inputs || return 1
+  policy_request_resolve_allow_workdir_config_writes
   policy_request_merge_add_dir_inputs \
     config_add_dirs_ro_inputs \
     env_add_dirs_ro_inputs \
@@ -5793,11 +5800,26 @@ policy_render_emit_scoped_sections() {
   policy_render_append_scoped_module_dir "profiles/65-apps" || return 1
 }
 
+# Emit terminal deny rules that must survive all path grants.
+# These are always last so no (allow file-write* (subpath …)) from workdir,
+# extra-access-rules, wide-read, or appended profiles can override them.
+policy_render_emit_terminal_deny_rules() {
+  # Keep safehouse configs safe
+  if [[ "$policy_req_allow_workdir_config_writes" -eq 1 ]]; then
+    return 0
+  fi
+  policy_render_write_line ";; #safehouse-test-id:terminal-deny-safehouse# Terminal deny rules are emitted last so they override any earlier path grants."
+  policy_render_write_line ";; Agents must never modify Safehouse config files regardless of workdir grants."
+  policy_render_write_line "(deny file-write* (regex #\"/\\.safehouse\$\"))"
+  policy_render_write_blank
+}
+
 policy_render_emit_dynamic_sections() {
   policy_render_emit_extra_access_rules || return 1
   policy_render_emit_wide_read_access
   policy_render_emit_workdir_access "$policy_req_effective_workdir" || return 1
   policy_render_append_cli_profiles || return 1
+  policy_render_emit_terminal_deny_rules || return 1
 }
 
 policy_render_emit_all_sections() {
@@ -6096,6 +6118,7 @@ policy_explain_print_summary() {
         echo "  selected scoped profile: ${profile} (${reason})"
       done
     fi
+    echo "  allow workdir config writes: $([[ "$policy_req_allow_workdir_config_writes" -eq 1 ]] && echo "enabled" || echo "disabled (default)")"
     echo "  sandbox denial log hint: /usr/bin/log show --last 2m --style compact --predicate 'eventMessage CONTAINS \"Sandbox:\" AND eventMessage CONTAINS \"deny(\"'"
   } >&2
 }
@@ -7376,6 +7399,14 @@ Policy scope options:
   --trust-workdir-config=BOOL
       Trust and load <workdir>/.safehouse (default: disabled)
 
+  --allow-workdir-config-writes
+      Skip the terminal deny-write rule for .safehouse config files.
+      By default, Safehouse always emits a deny file-write* rule for any
+      .safehouse file as the very last rule in the policy, ensuring agents
+      cannot modify workdir config regardless of path grants. Use this flag
+      only if you intentionally want the sandboxed process to be able to
+      write to .safehouse files.
+
   --append-profile PATH
   --append-profile=PATH
       Append an additional sandbox profile file after generated rules
@@ -7453,6 +7484,7 @@ cli_policy_workdir_set=0
 cli_policy_workdir_value=""
 cli_policy_trust_workdir_config_set=0
 cli_policy_trust_workdir_config_value=0
+cli_policy_allow_workdir_config_writes=0
 cli_policy_append_profiles=()
 cli_policy_output_path=""
 cli_policy_output_path_set=0
@@ -7480,6 +7512,7 @@ cli_parse_reset() {
   cli_policy_workdir_value=""
   cli_policy_trust_workdir_config_set=0
   cli_policy_trust_workdir_config_value=0
+  cli_policy_allow_workdir_config_writes=0
   cli_policy_append_profiles=()
   cli_policy_output_path=""
   cli_policy_output_path_set=0
@@ -7743,6 +7776,11 @@ cli_parse_policy_flag_option() {
         return 1
       fi
       cli_policy_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --allow-workdir-config-writes)
+      cli_policy_allow_workdir_config_writes=1
       cli_parse_consumed_args=1
       return 0
       ;;

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -8,6 +8,7 @@
 | `--add-dirs-ro=PATHS` | Colon-separated file/directory paths to grant read-only |
 | `--workdir=DIR` | Main directory to grant read/write (`--workdir=` disables automatic workdir grants) |
 | `--trust-workdir-config` | Trust and load `<workdir>/.safehouse` (`--trust-workdir-config=BOOL` also supported) |
+| `--allow-workdir-config-writes` | Skip the terminal deny-write rule for `.safehouse` config files (default: deny) |
 | `--append-profile=PATH` | Append sandbox profile file after generated rules (repeatable) |
 | `--enable=FEATURES` | Enable optional features (see list below) |
 | `--env` | Pass the full inherited host env to the wrapped command, including secrets (incompatible with `--env-pass`) |

--- a/docs/docs/policy-architecture.md
+++ b/docs/docs/policy-architecture.md
@@ -17,6 +17,7 @@ Policy assembly order:
 | `65-apps/*.sb` | Per-app bundle selection (`Claude.app`, `Visual Studio Code.app`) |
 | Config/env/CLI grants | Trusted `.safehouse` config, env grants, CLI grants, auto-detected app bundle read grant, selected workdir, launch-time active-worktree common-dir grant, and launch-time sibling worktree read grants |
 | Appended profiles | User profile overlays via `--append-profile` (loaded last) |
+| Terminal deny rules | Unconditional deny rules emitted after all path grants and appended profiles |
 
 ## Ordering Rules Matter
 
@@ -78,5 +79,11 @@ It is not a blanket grant for `$HOME`.
 Safehouse also generates a `file-read-metadata` block for `/`, the path to `$HOME`, and `$HOME` itself. That metadata-only traversal lets runtimes `stat` or walk toward explicitly allowed home-scoped paths without granting recursive reads of the whole home directory.
 
 In practice, that means `stat "$HOME"` can succeed while `ls "$HOME"` and `cat ~/secret.txt` still fail unless a more specific rule grants them.
+
+## Terminal Deny Rules
+
+To prevent accidentally granting access to some critical files Safehouse unconditionally emits a final deny block as the very last section of every generated policy. Since this block is always last, it wins over any earlier write grant regardless of how the workdir, additional profiles, etc are configured.
+
+Currently this is used to protect the `.safehouse` configuration file from being modified from inside the sandbox. To opt out pass `--allow-workdir-config-writes`.
 
 See also: [Bin Architecture](/docs/bin-architecture)

--- a/tests/policy/workdir/workdir-config.bats
+++ b/tests/policy/workdir/workdir-config.bats
@@ -72,3 +72,24 @@ load ../../test_helper.bash
   sft_assert_contains "$output" ".safehouse:1: allow-home"
   sft_assert_contains "$output" "Supported keys: add-dirs-ro, add-dirs"
 }
+
+@test "[POLICY-ONLY] generated policy contains terminal deny sentinel for .safehouse writes" {
+  local profile
+
+  profile="$(safehouse_profile)"
+  sft_assert_contains "$profile" "#safehouse-test-id:terminal-deny-safehouse#"
+}
+
+@test "[POLICY-ONLY] terminal deny rule appears after workdir grant" {
+  local profile
+
+  profile="$(safehouse_profile)"
+  sft_assert_order "$profile" "#safehouse-test-id:workdir-grant#" "#safehouse-test-id:terminal-deny-safehouse#"
+}
+
+@test "[POLICY-ONLY] --allow-workdir-config-writes suppresses the terminal deny rule" {
+  local profile
+
+  profile="$(safehouse_profile --allow-workdir-config-writes)"
+  sft_assert_not_contains "$profile" "terminal-deny-safehouse"
+}


### PR DESCRIPTION
In order to protect the .safehouse config from being written to from inside the sandbox this PR adds a terminal block to the generated seatbelt profile to allow for some final deny rules.

It adds a regex rule to deny all writes to `.safehouse` files. 
It also adds a CLI flag --allow-workdir-config-writes to opt out and allow writes to these files from inside the sandbox.

Co-written with Claude.
This PR is part of a set of 4 PRs aiming to make it possible to safely run `safehouse` while passing minimal options.