### PR TITLE
feat: extend .safehouse workdir config to support feature enablement and appended profiles

### DIFF
--- a/bin/lib/policy/explain.sh
+++ b/bin/lib/policy/explain.sh
@@ -178,6 +178,11 @@ policy_explain_print_summary() {
     else
       echo "  add-dirs (normalized): $(safehouse_join_by_space)"
     fi
+    if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+      echo "  workdir config appended profiles: $(safehouse_join_by_space "${policy_req_workdir_config_append_profile_paths[@]}")"
+    else
+      echo "  workdir config appended profiles: $(safehouse_join_by_space)"
+    fi
     if [[ "${#policy_plan_optional_integrations_explicit_included[@]}" -gt 0 ]]; then
       echo "  optional integrations explicitly enabled: $(safehouse_join_by_space "${policy_plan_optional_integrations_explicit_included[@]}")"
     else

--- a/bin/lib/policy/plan.sh
+++ b/bin/lib/policy/plan.sh
@@ -432,6 +432,12 @@ policy_plan_collect_runtime_env_defaults_from_scoped_profiles() {
 policy_plan_collect_runtime_env_defaults_from_appended_profiles() {
   local profile_path
 
+  if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+    for profile_path in "${policy_req_workdir_config_append_profile_paths[@]}"; do
+      policy_plan_append_profile_runtime_env_defaults_from_profile "$profile_path" || return 1
+    done
+  fi
+
   if [[ "$(safehouse_array_length policy_req_append_profile_paths)" -gt 0 ]]; then
     for profile_path in "${policy_req_append_profile_paths[@]}"; do
       policy_plan_append_profile_runtime_env_defaults_from_profile "$profile_path" || return 1

--- a/bin/lib/policy/render.sh
+++ b/bin/lib/policy/render.sh
@@ -653,6 +653,18 @@ policy_render_append_cli_profiles() {
   fi
 }
 
+policy_render_append_workdir_config_profiles() {
+  local profile_path
+
+  if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+    for profile_path in "${policy_req_workdir_config_append_profile_paths[@]}"; do
+      policy_render_write_line ";; #safehouse-test-id:workdir-config-append-profile# Appended profile from workdir config: ${profile_path}"
+      policy_render_write_blank
+      policy_render_append_profile "$profile_path" || return 1
+    done
+  fi
+}
+
 policy_render_reset_output_state() {
   policy_render_close_target_fd
   policy_render_output_path=""
@@ -719,6 +731,7 @@ policy_render_emit_dynamic_sections() {
   policy_render_emit_extra_access_rules || return 1
   policy_render_emit_wide_read_access
   policy_render_emit_workdir_access "$policy_req_effective_workdir" || return 1
+  policy_render_append_workdir_config_profiles || return 1
   policy_render_append_cli_profiles || return 1
 }
 

--- a/bin/lib/policy/render.sh
+++ b/bin/lib/policy/render.sh
@@ -675,6 +675,18 @@ policy_render_emit_append_profile_protections() {
   policy_render_write_blank
 }
 
+policy_render_append_workdir_config_profiles() {
+  local profile_path
+
+  if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+    for profile_path in "${policy_req_workdir_config_append_profile_paths[@]}"; do
+      policy_render_write_line ";; #safehouse-test-id:workdir-config-append-profile# Appended profile from workdir config: ${profile_path}"
+      policy_render_write_blank
+      policy_render_append_profile "$profile_path" || return 1
+    done
+  fi
+}
+
 policy_render_reset_output_state() {
   policy_render_close_target_fd
   policy_render_output_path=""
@@ -759,6 +771,7 @@ policy_render_emit_dynamic_sections() {
   policy_render_emit_extra_access_rules || return 1
   policy_render_emit_wide_read_access
   policy_render_emit_workdir_access "$policy_req_effective_workdir" || return 1
+  policy_render_append_workdir_config_profiles || return 1
   policy_render_append_cli_profiles || return 1
   policy_render_emit_append_profile_protections || return 1
   policy_render_emit_terminal_deny_rules || return 1

--- a/bin/lib/policy/render.sh
+++ b/bin/lib/policy/render.sh
@@ -655,20 +655,29 @@ policy_render_append_cli_profiles() {
 
 policy_render_emit_append_profile_protections() {
   local profile_path escaped_path
-  local cli_count
+  local -a protected_profile_paths=()
 
   if [[ "$policy_req_allow_profile_writes" -eq 1 ]]; then
     return 0
   fi
 
-  cli_count="$(safehouse_array_length policy_req_append_profile_paths)"
-  if [[ "$cli_count" -eq 0 ]]; then
+  # Both CLI --append-profile files and workdir config append-profile= files are
+  # policy files that govern the sandbox, so the agent must not be able to rewrite
+  # either of them.
+  if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+    protected_profile_paths+=("${policy_req_workdir_config_append_profile_paths[@]}")
+  fi
+  if [[ "$(safehouse_array_length policy_req_append_profile_paths)" -gt 0 ]]; then
+    protected_profile_paths+=("${policy_req_append_profile_paths[@]}")
+  fi
+
+  if [[ "${#protected_profile_paths[@]}" -eq 0 ]]; then
     return 0
   fi
 
   policy_render_write_line ";; #safehouse-test-id:append-profile-protections# Deny agent writes to appended policy files."
   policy_render_write_line ";; Use --allow-profile-writes to skip these deny rules."
-  for profile_path in "${policy_req_append_profile_paths[@]}"; do
+  for profile_path in "${protected_profile_paths[@]}"; do
     escaped_path="$(safehouse_escape_for_sb "$profile_path")" || return 1
     policy_render_write_line "(deny file-write* (literal \"${escaped_path}\"))"
   done

--- a/bin/lib/policy/request.sh
+++ b/bin/lib/policy/request.sh
@@ -29,6 +29,7 @@ policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
 policy_req_workdir_config_ignored_untrusted=0
+policy_req_workdir_config_append_profile_paths=()
 policy_req_invoked_command_path=""
 policy_req_invoked_command_basename=""
 policy_req_invoked_command_profile_path=""
@@ -82,12 +83,19 @@ policy_request_load_workdir_config_into_arrays() {
   local config_path="$1"
   local ro_target_name="$2"
   local rw_target_name="$3"
+  local enable_target_name="$4"
+  local append_profile_target_name="$5"
   local line trimmed key raw_value value
   local line_number=0
+  local config_dir resolved_profile_path
 
   safehouse_array_clear "$ro_target_name"
   safehouse_array_clear "$rw_target_name"
+  safehouse_array_clear "$enable_target_name"
+  safehouse_array_clear "$append_profile_target_name"
   [[ -f "$config_path" ]] || return 0
+
+  config_dir="$(dirname "$config_path")"
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_number=$((line_number + 1))
@@ -114,10 +122,22 @@ policy_request_load_workdir_config_into_arrays() {
       add-dirs|add_dirs|SAFEHOUSE_ADD_DIRS)
         safehouse_array_append "$rw_target_name" "$value"
         ;;
+      enable)
+        safehouse_array_append "$enable_target_name" "$value"
+        ;;
+      append-profile)
+        safehouse_validate_sb_string "$value" "append-profile path in workdir config" || return 1
+        if [[ "$value" != /* ]]; then
+          resolved_profile_path="${config_dir%/}/${value}"
+        else
+          resolved_profile_path="$value"
+        fi
+        safehouse_array_append "$append_profile_target_name" "$resolved_profile_path"
+        ;;
       *)
         safehouse_fail \
-          "Invalid config key in ${config_path}:${line_number}: ${key}" \
-          "Supported keys: add-dirs-ro, add-dirs"
+          "Unknown key in workdir config: ${key}" \
+          "Supported keys: add-dirs-ro, add-dirs, enable, append-profile"
         return 1
         ;;
     esac
@@ -166,6 +186,7 @@ policy_request_reset() {
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
   policy_req_workdir_config_ignored_untrusted=0
+  safehouse_array_clear policy_req_workdir_config_append_profile_paths
   policy_req_invoked_command_path=""
   policy_req_invoked_command_basename=""
   policy_req_invoked_command_profile_path=""
@@ -393,6 +414,9 @@ policy_request_resolve_append_profile_paths() {
 policy_request_load_effective_workdir_config() {
   local ro_target_name="$1"
   local rw_target_name="$2"
+  local -a config_enable_values=()
+  local -a config_append_profile_paths=()
+  local enable_value profile_path
 
   safehouse_array_clear "$ro_target_name"
   safehouse_array_clear "$rw_target_name"
@@ -413,7 +437,21 @@ policy_request_load_effective_workdir_config() {
         safehouse_fail "Workdir config file is not readable: $policy_req_workdir_config_path"
         return 1
       fi
-      policy_request_load_workdir_config_into_arrays "$policy_req_workdir_config_path" "$ro_target_name" "$rw_target_name" || return 1
+      policy_request_load_workdir_config_into_arrays \
+        "$policy_req_workdir_config_path" \
+        "$ro_target_name" \
+        "$rw_target_name" \
+        config_enable_values \
+        config_append_profile_paths || return 1
+
+      for enable_value in "${config_enable_values[@]}"; do
+        policy_request_parse_enable_csv "$enable_value" || return 1
+      done
+
+      for profile_path in "${config_append_profile_paths[@]}"; do
+        safehouse_array_append policy_req_workdir_config_append_profile_paths "$profile_path"
+      done
+
       policy_req_workdir_config_loaded=1
     fi
     return 0

--- a/bin/lib/policy/request.sh
+++ b/bin/lib/policy/request.sh
@@ -31,6 +31,7 @@ policy_req_workdir_config_found=0
 policy_req_workdir_config_ignored_untrusted=0
 policy_req_allow_workdir_config_writes=0
 policy_req_allow_profile_writes=0
+policy_req_workdir_config_append_profile_paths=()
 policy_req_invoked_command_path=""
 policy_req_invoked_command_basename=""
 policy_req_invoked_command_profile_path=""
@@ -84,12 +85,19 @@ policy_request_load_workdir_config_into_arrays() {
   local config_path="$1"
   local ro_target_name="$2"
   local rw_target_name="$3"
+  local enable_target_name="$4"
+  local append_profile_target_name="$5"
   local line trimmed key raw_value value
   local line_number=0
+  local config_dir resolved_profile_path
 
   safehouse_array_clear "$ro_target_name"
   safehouse_array_clear "$rw_target_name"
+  safehouse_array_clear "$enable_target_name"
+  safehouse_array_clear "$append_profile_target_name"
   [[ -f "$config_path" ]] || return 0
+
+  config_dir="$(dirname "$config_path")"
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_number=$((line_number + 1))
@@ -116,10 +124,22 @@ policy_request_load_workdir_config_into_arrays() {
       add-dirs|add_dirs|SAFEHOUSE_ADD_DIRS)
         safehouse_array_append "$rw_target_name" "$value"
         ;;
+      enable)
+        safehouse_array_append "$enable_target_name" "$value"
+        ;;
+      append-profile)
+        safehouse_validate_sb_string "$value" "append-profile path in workdir config" || return 1
+        if [[ "$value" != /* ]]; then
+          resolved_profile_path="${config_dir%/}/${value}"
+        else
+          resolved_profile_path="$value"
+        fi
+        safehouse_array_append "$append_profile_target_name" "$resolved_profile_path"
+        ;;
       *)
         safehouse_fail \
           "Invalid config key in ${config_path}:${line_number}: ${key}" \
-          "Supported keys: add-dirs-ro, add-dirs"
+          "Supported keys: add-dirs-ro, add-dirs, enable, append-profile"
         return 1
         ;;
     esac
@@ -170,6 +190,7 @@ policy_request_reset() {
   policy_req_workdir_config_ignored_untrusted=0
   policy_req_allow_workdir_config_writes=0
   policy_req_allow_profile_writes=0
+  safehouse_array_clear policy_req_workdir_config_append_profile_paths
   policy_req_invoked_command_path=""
   policy_req_invoked_command_basename=""
   policy_req_invoked_command_profile_path=""
@@ -397,6 +418,9 @@ policy_request_resolve_append_profile_paths() {
 policy_request_load_effective_workdir_config() {
   local ro_target_name="$1"
   local rw_target_name="$2"
+  local -a config_enable_values=()
+  local -a config_append_profile_paths=()
+  local enable_value profile_path
 
   safehouse_array_clear "$ro_target_name"
   safehouse_array_clear "$rw_target_name"
@@ -417,7 +441,25 @@ policy_request_load_effective_workdir_config() {
         safehouse_fail "Workdir config file is not readable: $policy_req_workdir_config_path"
         return 1
       fi
-      policy_request_load_workdir_config_into_arrays "$policy_req_workdir_config_path" "$ro_target_name" "$rw_target_name" || return 1
+      policy_request_load_workdir_config_into_arrays \
+        "$policy_req_workdir_config_path" \
+        "$ro_target_name" \
+        "$rw_target_name" \
+        config_enable_values \
+        config_append_profile_paths || return 1
+
+      if [[ "$(safehouse_array_length config_enable_values)" -gt 0 ]]; then
+        for enable_value in "${config_enable_values[@]}"; do
+          policy_request_parse_enable_csv "$enable_value" || return 1
+        done
+      fi
+
+      if [[ "$(safehouse_array_length config_append_profile_paths)" -gt 0 ]]; then
+        for profile_path in "${config_append_profile_paths[@]}"; do
+          safehouse_array_append policy_req_workdir_config_append_profile_paths "$profile_path"
+        done
+      fi
+
       policy_req_workdir_config_loaded=1
     fi
     return 0

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -4151,6 +4151,7 @@ policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
 policy_req_workdir_config_ignored_untrusted=0
+policy_req_workdir_config_append_profile_paths=()
 policy_req_invoked_command_path=""
 policy_req_invoked_command_basename=""
 policy_req_invoked_command_profile_path=""
@@ -4204,12 +4205,19 @@ policy_request_load_workdir_config_into_arrays() {
   local config_path="$1"
   local ro_target_name="$2"
   local rw_target_name="$3"
+  local enable_target_name="$4"
+  local append_profile_target_name="$5"
   local line trimmed key raw_value value
   local line_number=0
+  local config_dir resolved_profile_path
 
   safehouse_array_clear "$ro_target_name"
   safehouse_array_clear "$rw_target_name"
+  safehouse_array_clear "$enable_target_name"
+  safehouse_array_clear "$append_profile_target_name"
   [[ -f "$config_path" ]] || return 0
+
+  config_dir="$(dirname "$config_path")"
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_number=$((line_number + 1))
@@ -4236,10 +4244,22 @@ policy_request_load_workdir_config_into_arrays() {
       add-dirs|add_dirs|SAFEHOUSE_ADD_DIRS)
         safehouse_array_append "$rw_target_name" "$value"
         ;;
+      enable)
+        safehouse_array_append "$enable_target_name" "$value"
+        ;;
+      append-profile)
+        safehouse_validate_sb_string "$value" "append-profile path in workdir config" || return 1
+        if [[ "$value" != /* ]]; then
+          resolved_profile_path="${config_dir%/}/${value}"
+        else
+          resolved_profile_path="$value"
+        fi
+        safehouse_array_append "$append_profile_target_name" "$resolved_profile_path"
+        ;;
       *)
         safehouse_fail \
-          "Invalid config key in ${config_path}:${line_number}: ${key}" \
-          "Supported keys: add-dirs-ro, add-dirs"
+          "Unknown key in workdir config: ${key}" \
+          "Supported keys: add-dirs-ro, add-dirs, enable, append-profile"
         return 1
         ;;
     esac
@@ -4288,6 +4308,7 @@ policy_request_reset() {
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
   policy_req_workdir_config_ignored_untrusted=0
+  safehouse_array_clear policy_req_workdir_config_append_profile_paths
   policy_req_invoked_command_path=""
   policy_req_invoked_command_basename=""
   policy_req_invoked_command_profile_path=""
@@ -4515,6 +4536,9 @@ policy_request_resolve_append_profile_paths() {
 policy_request_load_effective_workdir_config() {
   local ro_target_name="$1"
   local rw_target_name="$2"
+  local -a config_enable_values=()
+  local -a config_append_profile_paths=()
+  local enable_value profile_path
 
   safehouse_array_clear "$ro_target_name"
   safehouse_array_clear "$rw_target_name"
@@ -4535,7 +4559,21 @@ policy_request_load_effective_workdir_config() {
         safehouse_fail "Workdir config file is not readable: $policy_req_workdir_config_path"
         return 1
       fi
-      policy_request_load_workdir_config_into_arrays "$policy_req_workdir_config_path" "$ro_target_name" "$rw_target_name" || return 1
+      policy_request_load_workdir_config_into_arrays \
+        "$policy_req_workdir_config_path" \
+        "$ro_target_name" \
+        "$rw_target_name" \
+        config_enable_values \
+        config_append_profile_paths || return 1
+
+      for enable_value in "${config_enable_values[@]}"; do
+        policy_request_parse_enable_csv "$enable_value" || return 1
+      done
+
+      for profile_path in "${config_append_profile_paths[@]}"; do
+        safehouse_array_append policy_req_workdir_config_append_profile_paths "$profile_path"
+      done
+
       policy_req_workdir_config_loaded=1
     fi
     return 0
@@ -5731,6 +5769,18 @@ policy_render_append_cli_profiles() {
   fi
 }
 
+policy_render_append_workdir_config_profiles() {
+  local profile_path
+
+  if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+    for profile_path in "${policy_req_workdir_config_append_profile_paths[@]}"; do
+      policy_render_write_line ";; #safehouse-test-id:workdir-config-append-profile# Appended profile from workdir config: ${profile_path}"
+      policy_render_write_blank
+      policy_render_append_profile "$profile_path" || return 1
+    done
+  fi
+}
+
 policy_render_reset_output_state() {
   policy_render_close_target_fd
   policy_render_output_path=""
@@ -5797,6 +5847,7 @@ policy_render_emit_dynamic_sections() {
   policy_render_emit_extra_access_rules || return 1
   policy_render_emit_wide_read_access
   policy_render_emit_workdir_access "$policy_req_effective_workdir" || return 1
+  policy_render_append_workdir_config_profiles || return 1
   policy_render_append_cli_profiles || return 1
 }
 
@@ -6044,6 +6095,11 @@ policy_explain_print_summary() {
       echo "  add-dirs (normalized): $(safehouse_join_by_space "${policy_plan_rw_paths[@]}")"
     else
       echo "  add-dirs (normalized): $(safehouse_join_by_space)"
+    fi
+    if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+      echo "  workdir config appended profiles: $(safehouse_join_by_space "${policy_req_workdir_config_append_profile_paths[@]}")"
+    else
+      echo "  workdir config appended profiles: $(safehouse_join_by_space)"
     fi
     if [[ "${#policy_plan_optional_integrations_explicit_included[@]}" -gt 0 ]]; then
       echo "  optional integrations explicitly enabled: $(safehouse_join_by_space "${policy_plan_optional_integrations_explicit_included[@]}")"

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -5938,20 +5938,29 @@ policy_render_append_cli_profiles() {
 
 policy_render_emit_append_profile_protections() {
   local profile_path escaped_path
-  local cli_count
+  local -a protected_profile_paths=()
 
   if [[ "$policy_req_allow_profile_writes" -eq 1 ]]; then
     return 0
   fi
 
-  cli_count="$(safehouse_array_length policy_req_append_profile_paths)"
-  if [[ "$cli_count" -eq 0 ]]; then
+  # Both CLI --append-profile files and workdir config append-profile= files are
+  # policy files that govern the sandbox, so the agent must not be able to rewrite
+  # either of them.
+  if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+    protected_profile_paths+=("${policy_req_workdir_config_append_profile_paths[@]}")
+  fi
+  if [[ "$(safehouse_array_length policy_req_append_profile_paths)" -gt 0 ]]; then
+    protected_profile_paths+=("${policy_req_append_profile_paths[@]}")
+  fi
+
+  if [[ "${#protected_profile_paths[@]}" -eq 0 ]]; then
     return 0
   fi
 
   policy_render_write_line ";; #safehouse-test-id:append-profile-protections# Deny agent writes to appended policy files."
   policy_render_write_line ";; Use --allow-profile-writes to skip these deny rules."
-  for profile_path in "${policy_req_append_profile_paths[@]}"; do
+  for profile_path in "${protected_profile_paths[@]}"; do
     escaped_path="$(safehouse_escape_for_sb "$profile_path")" || return 1
     policy_render_write_line "(deny file-write* (literal \"${escaped_path}\"))"
   done

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -4296,6 +4296,7 @@ policy_req_workdir_config_found=0
 policy_req_workdir_config_ignored_untrusted=0
 policy_req_allow_workdir_config_writes=0
 policy_req_allow_profile_writes=0
+policy_req_workdir_config_append_profile_paths=()
 policy_req_invoked_command_path=""
 policy_req_invoked_command_basename=""
 policy_req_invoked_command_profile_path=""
@@ -4349,12 +4350,19 @@ policy_request_load_workdir_config_into_arrays() {
   local config_path="$1"
   local ro_target_name="$2"
   local rw_target_name="$3"
+  local enable_target_name="$4"
+  local append_profile_target_name="$5"
   local line trimmed key raw_value value
   local line_number=0
+  local config_dir resolved_profile_path
 
   safehouse_array_clear "$ro_target_name"
   safehouse_array_clear "$rw_target_name"
+  safehouse_array_clear "$enable_target_name"
+  safehouse_array_clear "$append_profile_target_name"
   [[ -f "$config_path" ]] || return 0
+
+  config_dir="$(dirname "$config_path")"
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_number=$((line_number + 1))
@@ -4381,10 +4389,22 @@ policy_request_load_workdir_config_into_arrays() {
       add-dirs|add_dirs|SAFEHOUSE_ADD_DIRS)
         safehouse_array_append "$rw_target_name" "$value"
         ;;
+      enable)
+        safehouse_array_append "$enable_target_name" "$value"
+        ;;
+      append-profile)
+        safehouse_validate_sb_string "$value" "append-profile path in workdir config" || return 1
+        if [[ "$value" != /* ]]; then
+          resolved_profile_path="${config_dir%/}/${value}"
+        else
+          resolved_profile_path="$value"
+        fi
+        safehouse_array_append "$append_profile_target_name" "$resolved_profile_path"
+        ;;
       *)
         safehouse_fail \
           "Invalid config key in ${config_path}:${line_number}: ${key}" \
-          "Supported keys: add-dirs-ro, add-dirs"
+          "Supported keys: add-dirs-ro, add-dirs, enable, append-profile"
         return 1
         ;;
     esac
@@ -4435,6 +4455,7 @@ policy_request_reset() {
   policy_req_workdir_config_ignored_untrusted=0
   policy_req_allow_workdir_config_writes=0
   policy_req_allow_profile_writes=0
+  safehouse_array_clear policy_req_workdir_config_append_profile_paths
   policy_req_invoked_command_path=""
   policy_req_invoked_command_basename=""
   policy_req_invoked_command_profile_path=""
@@ -4662,6 +4683,9 @@ policy_request_resolve_append_profile_paths() {
 policy_request_load_effective_workdir_config() {
   local ro_target_name="$1"
   local rw_target_name="$2"
+  local -a config_enable_values=()
+  local -a config_append_profile_paths=()
+  local enable_value profile_path
 
   safehouse_array_clear "$ro_target_name"
   safehouse_array_clear "$rw_target_name"
@@ -4682,7 +4706,25 @@ policy_request_load_effective_workdir_config() {
         safehouse_fail "Workdir config file is not readable: $policy_req_workdir_config_path"
         return 1
       fi
-      policy_request_load_workdir_config_into_arrays "$policy_req_workdir_config_path" "$ro_target_name" "$rw_target_name" || return 1
+      policy_request_load_workdir_config_into_arrays \
+        "$policy_req_workdir_config_path" \
+        "$ro_target_name" \
+        "$rw_target_name" \
+        config_enable_values \
+        config_append_profile_paths || return 1
+
+      if [[ "$(safehouse_array_length config_enable_values)" -gt 0 ]]; then
+        for enable_value in "${config_enable_values[@]}"; do
+          policy_request_parse_enable_csv "$enable_value" || return 1
+        done
+      fi
+
+      if [[ "$(safehouse_array_length config_append_profile_paths)" -gt 0 ]]; then
+        for profile_path in "${config_append_profile_paths[@]}"; do
+          safehouse_array_append policy_req_workdir_config_append_profile_paths "$profile_path"
+        done
+      fi
+
       policy_req_workdir_config_loaded=1
     fi
     return 0
@@ -5206,6 +5248,12 @@ policy_plan_collect_runtime_env_defaults_from_scoped_profiles() {
 
 policy_plan_collect_runtime_env_defaults_from_appended_profiles() {
   local profile_path
+
+  if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+    for profile_path in "${policy_req_workdir_config_append_profile_paths[@]}"; do
+      policy_plan_append_profile_runtime_env_defaults_from_profile "$profile_path" || return 1
+    done
+  fi
 
   if [[ "$(safehouse_array_length policy_req_append_profile_paths)" -gt 0 ]]; then
     for profile_path in "${policy_req_append_profile_paths[@]}"; do
@@ -5910,6 +5958,18 @@ policy_render_emit_append_profile_protections() {
   policy_render_write_blank
 }
 
+policy_render_append_workdir_config_profiles() {
+  local profile_path
+
+  if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+    for profile_path in "${policy_req_workdir_config_append_profile_paths[@]}"; do
+      policy_render_write_line ";; #safehouse-test-id:workdir-config-append-profile# Appended profile from workdir config: ${profile_path}"
+      policy_render_write_blank
+      policy_render_append_profile "$profile_path" || return 1
+    done
+  fi
+}
+
 policy_render_reset_output_state() {
   policy_render_close_target_fd
   policy_render_output_path=""
@@ -5994,6 +6054,7 @@ policy_render_emit_dynamic_sections() {
   policy_render_emit_extra_access_rules || return 1
   policy_render_emit_wide_read_access
   policy_render_emit_workdir_access "$policy_req_effective_workdir" || return 1
+  policy_render_append_workdir_config_profiles || return 1
   policy_render_append_cli_profiles || return 1
   policy_render_emit_append_profile_protections || return 1
   policy_render_emit_terminal_deny_rules || return 1
@@ -6243,6 +6304,11 @@ policy_explain_print_summary() {
       echo "  add-dirs (normalized): $(safehouse_join_by_space "${policy_plan_rw_paths[@]}")"
     else
       echo "  add-dirs (normalized): $(safehouse_join_by_space)"
+    fi
+    if [[ "$(safehouse_array_length policy_req_workdir_config_append_profile_paths)" -gt 0 ]]; then
+      echo "  workdir config appended profiles: $(safehouse_join_by_space "${policy_req_workdir_config_append_profile_paths[@]}")"
+    else
+      echo "  workdir config appended profiles: $(safehouse_join_by_space)"
     fi
     if [[ "${#policy_plan_optional_integrations_explicit_included[@]}" -gt 0 ]]; then
       echo "  optional integrations explicitly enabled: $(safehouse_join_by_space "${policy_plan_optional_integrations_explicit_included[@]}")"

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -111,10 +111,14 @@ Supported keys:
 
 - `add-dirs-ro=PATHS`
 - `add-dirs=PATHS`
+- `enable=FEATURES` — same values as `--enable`; comma-separated, repeatable
+- `append-profile=PATH` — path relative to the workdir or absolute; repeatable
 
 By default this file is ignored. It is loaded only with `--trust-workdir-config` (or `SAFEHOUSE_TRUST_WORKDIR_CONFIG`).
 Because the default workdir is the invocation directory, Safehouse does not auto-discover `.safehouse` files from enclosing Git repo roots when you launch from a nested subdirectory.
 Trusted config parsing fails fast on malformed lines and unknown keys.
+
+Workdir config `append-profile=` files are applied before CLI `--append-profile` files, so CLI flags always take final precedence.
 
 ## `--env=FILE` Format
 

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -115,12 +115,16 @@ Path: `<workdir>/.safehouse`
 
 Supported keys:
 
-- `add-dirs-ro=PATHS`
-- `add-dirs=PATHS`
+- `add-dirs-ro=PATHS` — colon-separated read-only path grants; repeatable
+- `add-dirs=PATHS` — colon-separated read/write path grants; repeatable
+- `enable=FEATURES` — same values as `--enable`; comma-separated, repeatable
+- `append-profile=PATH` — path relative to the workdir or absolute; repeatable
 
 By default this file is ignored. It is loaded only with `--trust-workdir-config` (or `SAFEHOUSE_TRUST_WORKDIR_CONFIG`).
 Because the default workdir is the invocation directory, Safehouse does not auto-discover `.safehouse` files from enclosing Git repo roots when you launch from a nested subdirectory.
 Trusted config parsing fails fast on malformed lines and unknown keys.
+
+Workdir config `append-profile=` files are applied before CLI `--append-profile` files, so CLI flags always take final precedence.
 
 ## `--env=FILE` Format
 

--- a/tests/policy/workdir/workdir-config.bats
+++ b/tests/policy/workdir/workdir-config.bats
@@ -68,7 +68,74 @@ load ../../test_helper.bash
 
   safehouse_run --trust-workdir-config --stdout
   [ "$status" -ne 0 ]
-  sft_assert_contains "$output" "Invalid config key in "
-  sft_assert_contains "$output" ".safehouse:1: allow-home"
-  sft_assert_contains "$output" "Supported keys: add-dirs-ro, add-dirs"
+  sft_assert_contains "$output" "Unknown key in workdir config: allow-home"
+  sft_assert_contains "$output" "Supported keys: add-dirs-ro, add-dirs, enable, append-profile"
+}
+
+@test "[POLICY-ONLY] trusted .safehouse with enable=docker enables docker integration" {
+  local config_file explain_log
+
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+  explain_log="$(sft_workspace_path "explain.log")" || return 1
+
+  printf 'enable=docker\n' > "$config_file"
+
+  trusted_profile="$(safehouse_profile --trust-workdir-config)"
+  sft_assert_contains "$trusted_profile" "Integration: Docker"
+
+  safehouse_ok --trust-workdir-config --explain --stdout >/dev/null 2>"$explain_log"
+  sft_assert_file_contains "$explain_log" "docker"
+}
+
+@test "[POLICY-ONLY] trusted .safehouse with append-profile= appends the profile" {
+  local config_file profile_file profile_dir profile
+
+  profile_dir="$(mktemp -d "${SAFEHOUSE_WORKSPACE}/profiles.XXXXXX")" || return 1
+  profile_file="${profile_dir}/custom.sb"
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  printf ';; custom-test-marker\n(allow file-read* (literal "/tmp"))\n' > "$profile_file"
+
+  printf 'append-profile=%s\n' "$profile_file" > "$config_file"
+
+  profile="$(safehouse_profile --trust-workdir-config)"
+  sft_assert_contains "$profile" "#safehouse-test-id:workdir-config-append-profile#"
+  sft_assert_contains "$profile" "custom-test-marker"
+}
+
+@test "[POLICY-ONLY] trusted .safehouse append-profile appears before --append-profile in policy" {
+  local config_file workdir_profile_file cli_profile_file profile
+
+  workdir_profile_file="$(sft_workspace_path "workdir-extra.sb")" || return 1
+  cli_profile_file="$(sft_workspace_path "cli-extra.sb")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  printf ';; workdir-config-marker\n' > "$workdir_profile_file"
+  printf ';; cli-append-marker\n' > "$cli_profile_file"
+
+  printf 'append-profile=%s\n' "$workdir_profile_file" > "$config_file"
+
+  profile="$(safehouse_profile --trust-workdir-config --append-profile="$cli_profile_file")"
+  sft_assert_order "$profile" "#safehouse-test-id:workdir-config-append-profile#" "#safehouse-test-id:append-profile#"
+}
+
+@test "[POLICY-ONLY] untrusted .safehouse enable= is ignored" {
+  local config_file profile
+
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+  printf 'enable=docker\n' > "$config_file"
+
+  profile="$(safehouse_profile)"
+  sft_assert_not_contains "$profile" "Integration: Docker"
+}
+
+@test "unknown key in .safehouse fails" {
+  local config_file
+
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+  printf 'badkey=value\n' > "$config_file"
+
+  safehouse_run --trust-workdir-config --stdout
+  [ "$status" -ne 0 ]
+  sft_assert_contains "$output" "Unknown key in workdir config: badkey"
 }

--- a/tests/policy/workdir/workdir-config.bats
+++ b/tests/policy/workdir/workdir-config.bats
@@ -104,6 +104,35 @@ load ../../test_helper.bash
   sft_assert_contains "$profile" "custom-test-marker"
 }
 
+@test "[POLICY-ONLY] trusted .safehouse append-profile adds deny-write rule for the profile file" {
+  local config_file profile_file profile_dir profile
+
+  profile_dir="$(mktemp -d "${SAFEHOUSE_WORKSPACE}/profiles.XXXXXX")" || return 1
+  profile_file="${profile_dir}/custom.sb"
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  printf ';; custom-test-marker\n' > "$profile_file"
+  printf 'append-profile=%s\n' "$profile_file" > "$config_file"
+
+  profile="$(safehouse_profile --trust-workdir-config)"
+  sft_assert_contains "$profile" "#safehouse-test-id:append-profile-protections#"
+  sft_assert_contains "$profile" "(deny file-write* (literal \"${profile_file}\"))"
+}
+
+@test "[POLICY-ONLY] --allow-profile-writes suppresses the deny-write rule for .safehouse append-profile" {
+  local config_file profile_file profile_dir profile
+
+  profile_dir="$(mktemp -d "${SAFEHOUSE_WORKSPACE}/profiles.XXXXXX")" || return 1
+  profile_file="${profile_dir}/custom.sb"
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  printf ';; custom-test-marker\n' > "$profile_file"
+  printf 'append-profile=%s\n' "$profile_file" > "$config_file"
+
+  profile="$(safehouse_profile --trust-workdir-config --allow-profile-writes)"
+  sft_assert_not_contains "$profile" "(deny file-write* (literal \"${profile_file}\"))"
+}
+
 @test "[POLICY-ONLY] trusted .safehouse append-profile appears before --append-profile in policy" {
   local config_file workdir_profile_file cli_profile_file profile
 

--- a/tests/policy/workdir/workdir-config.bats
+++ b/tests/policy/workdir/workdir-config.bats
@@ -61,16 +61,86 @@ load ../../test_helper.bash
 }
 
 @test "trusted workdir config rejects unknown keys" {
-  local config_file
+  local config_file real_config_file
 
   config_file="$(sft_workspace_path ".safehouse")" || return 1
   printf '%s\n' 'allow-home=true' > "$config_file"
+  real_config_file="$(realpath "$config_file")"
 
   safehouse_run --trust-workdir-config --stdout
   [ "$status" -ne 0 ]
-  sft_assert_contains "$output" "Invalid config key in "
-  sft_assert_contains "$output" ".safehouse:1: allow-home"
-  sft_assert_contains "$output" "Supported keys: add-dirs-ro, add-dirs"
+  sft_assert_contains "$output" "Invalid config key in ${real_config_file}:1: allow-home"
+  sft_assert_contains "$output" "Supported keys: add-dirs-ro, add-dirs, enable, append-profile"
+}
+
+@test "[POLICY-ONLY] trusted .safehouse with enable=docker enables docker integration" {
+  local config_file explain_log
+
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+  explain_log="$(sft_workspace_path "explain.log")" || return 1
+
+  printf 'enable=docker\n' > "$config_file"
+
+  trusted_profile="$(safehouse_profile --trust-workdir-config)"
+  sft_assert_contains "$trusted_profile" "Integration: Docker"
+
+  safehouse_ok --trust-workdir-config --explain --stdout >/dev/null 2>"$explain_log"
+  sft_assert_file_contains "$explain_log" "docker"
+}
+
+@test "[POLICY-ONLY] trusted .safehouse with append-profile= appends the profile" {
+  local config_file profile_file profile_dir profile
+
+  profile_dir="$(mktemp -d "${SAFEHOUSE_WORKSPACE}/profiles.XXXXXX")" || return 1
+  profile_file="${profile_dir}/custom.sb"
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  printf ';; custom-test-marker\n(allow file-read* (literal "/tmp"))\n' > "$profile_file"
+
+  printf 'append-profile=%s\n' "$profile_file" > "$config_file"
+
+  profile="$(safehouse_profile --trust-workdir-config)"
+  sft_assert_contains "$profile" "#safehouse-test-id:workdir-config-append-profile#"
+  sft_assert_contains "$profile" "custom-test-marker"
+}
+
+@test "[POLICY-ONLY] trusted .safehouse append-profile appears before --append-profile in policy" {
+  local config_file workdir_profile_file cli_profile_file profile
+
+  workdir_profile_file="$(sft_workspace_path "workdir-extra.sb")" || return 1
+  cli_profile_file="$(sft_workspace_path "cli-extra.sb")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  printf ';; workdir-config-marker\n' > "$workdir_profile_file"
+  printf ';; cli-append-marker\n' > "$cli_profile_file"
+
+  printf 'append-profile=%s\n' "$workdir_profile_file" > "$config_file"
+
+  profile="$(safehouse_profile --trust-workdir-config --append-profile="$cli_profile_file")"
+  sft_assert_order "$profile" "#safehouse-test-id:workdir-config-append-profile#" "#safehouse-test-id:append-profile#"
+}
+
+@test "[POLICY-ONLY] untrusted .safehouse enable= is ignored" {
+  local config_file profile
+
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+  printf 'enable=docker\n' > "$config_file"
+
+  profile="$(safehouse_profile)"
+  sft_assert_not_contains "$profile" "Integration: Docker"
+}
+
+@test "unknown key in .safehouse fails" {
+  local config_file real_config_file
+
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+  printf 'badkey=value\n' > "$config_file"
+  real_config_file="$(realpath "$config_file")"
+
+  safehouse_run --trust-workdir-config --stdout
+  [ "$status" -ne 0 ]
+  sft_assert_contains "$output" "Invalid config key in ${real_config_file}:1: badkey"
+  sft_assert_contains "$output" "Supported keys: add-dirs-ro, add-dirs, enable, append-profile"
 }
 
 @test "[POLICY-ONLY] generated policy contains terminal deny sentinel for .safehouse writes" {

--- a/tests/surface/cli/explain.bats
+++ b/tests/surface/cli/explain.bats
@@ -125,3 +125,19 @@ load ../../test_helper.bash
   sft_assert_file_contains "$explain_log" "git linked worktree read grants: ${sibling_worktree}"
   sft_assert_file_not_contains "$explain_log" "$stale_worktree"
 }
+
+@test "--explain reports exec-env-default from workdir config append-profile=" {
+  local explain_log profile_file config_file workdir
+
+  explain_log="$(sft_workspace_path "explain-workdir-cfg-env.log")"
+  workdir="$(sft_external_dir "explain-workdir-cfg-env")" || return 1
+  profile_file="${workdir}/extra.sb"
+  config_file="${workdir}/.safehouse"
+
+  printf ';; $$exec-env-default=SAFEHOUSE_CFG_TEST=from-config$$\n' > "$profile_file"
+  printf 'append-profile=%s\n' "$profile_file" > "$config_file"
+
+  safehouse_ok_in_dir "$workdir" --trust-workdir-config --explain --stdout >/dev/null 2>"$explain_log"
+
+  sft_assert_file_contains "$explain_log" "profile env defaults: SAFEHOUSE_CFG_TEST=from-config"
+}


### PR DESCRIPTION
Add enable= and append-profile= keys to trusted .safehouse workdir config files. enable= accepts the same comma-separated feature names as --enable (e.g. enable=docker,ssh). append-profile= accepts a path relative to the workdir or absolute.

Workdir config append-profile files are applied before CLI --append-profile files, so CLI profiles always take final precedence.

As this PR stands that means that a .safehouse file could append a profile which denies some features which are enabled on the CLI, which isn't ideal, but it was a larger refactor to untangle that, so I'm open to feedback on that aspect of CLI > config file.

Co-written with Claude.
This PR is part of a set of 4 PRs aiming to make it possible to safely run `safehouse` while passing minimal options.