### PR TITLE
feat: add always trusted workdir configs

### DIFF
--- a/bin/lib/bootstrap/constants.sh
+++ b/bin/lib/bootstrap/constants.sh
@@ -13,6 +13,7 @@ safehouse_project_github_url="https://github.com/eugene1g/agent-safehouse"
 safehouse_project_release_asset_url="${safehouse_project_github_url}/releases/latest/download/safehouse.sh"
 safehouse_project_head_asset_url="https://raw.githubusercontent.com/eugene1g/agent-safehouse/main/dist/safehouse.sh"
 safehouse_workdir_config_filename=".safehouse"
+safehouse_trusted_workdirs_config_relpath=".config/safehouse/trusted-workdirs"
 
 resolve_safehouse_project_version() {
   local version=""

--- a/bin/lib/cli/output.sh
+++ b/bin/lib/cli/output.sh
@@ -99,6 +99,13 @@ Policy scope options:
   --trust-workdir-config=BOOL
       Trust and load <workdir>/.safehouse (default: disabled)
 
+  --always-trust-workdir-config
+  --always-trust-workdir-config=BOOL
+      Save workdir to ~/.config/safehouse/trusted-workdirs and trust it for this
+      invocation. Future invocations in this directory will automatically load
+      <workdir>/.safehouse without needing this flag again.
+      Conflicts with --trust-workdir-config=false/0/no/off (contradictory).
+
   --append-profile PATH
   --append-profile=PATH
       Append an additional sandbox profile file after generated rules
@@ -152,5 +159,9 @@ Config file:
       Supports keys:
         add-dirs-ro=PATHS
         add-dirs=PATHS
+
+  ~/.config/safehouse/trusted-workdirs (optional, always read)
+      One trusted directory path per line; blank lines and # comments allowed
+      Written by --always-trust-workdir-config; edit directly to remove entries
 USAGE
 }

--- a/bin/lib/cli/output.sh
+++ b/bin/lib/cli/output.sh
@@ -97,7 +97,13 @@ Policy scope options:
 
   --trust-workdir-config
   --trust-workdir-config=BOOL
-      Trust and load <workdir>/.safehouse (default: disabled)
+      Trust and load <workdir>/.safehouse this session (default: disabled)
+
+  --always-trust-workdir-config
+  --always-trust-workdir-config=BOOL
+      Trust and load <workdir>/.safehouse this and future sessions (default:
+      disabled). Remember <workdir> in ~/.config/safehouse/trusted-workdirs.
+      Conflicts with --trust-workdir-config=false/0/no/off.
 
   --allow-workdir-config-writes
       Skip the terminal deny-write rule for the workdir config file.
@@ -167,5 +173,10 @@ Config file:
       Supports keys:
         add-dirs-ro=PATHS
         add-dirs=PATHS
+
+  ~/.config/safehouse/trusted-workdirs (optional, always read)
+      One trusted directory path per line; blank lines and # comments allowed
+      Written by --always-trust-workdir-config. To remove entries edit directly
+      or use --always-trust-workdir-config=false.
 USAGE
 }

--- a/bin/lib/cli/parse.sh
+++ b/bin/lib/cli/parse.sh
@@ -19,6 +19,8 @@ cli_policy_workdir_set=0
 cli_policy_workdir_value=""
 cli_policy_trust_workdir_config_set=0
 cli_policy_trust_workdir_config_value=0
+cli_policy_always_trust_workdir_config=0
+cli_policy_always_trust_workdir_config_set=0
 cli_policy_append_profiles=()
 cli_policy_output_path=""
 cli_policy_output_path_set=0
@@ -46,6 +48,8 @@ cli_parse_reset() {
   cli_policy_workdir_value=""
   cli_policy_trust_workdir_config_set=0
   cli_policy_trust_workdir_config_value=0
+  cli_policy_always_trust_workdir_config=0
+  cli_policy_always_trust_workdir_config_set=0
   cli_policy_append_profiles=()
   cli_policy_output_path=""
   cli_policy_output_path_set=0
@@ -211,6 +215,14 @@ cli_finalize_post_parse_state() {
   cli_finalize_runtime_env_inputs || return 1
   cli_finalize_wrapped_command_inputs || return 1
 
+  if [[ "$cli_policy_always_trust_workdir_config" -eq 1 && \
+        "$cli_policy_trust_workdir_config_set" -eq 1 && \
+        "$cli_policy_trust_workdir_config_value" -eq 0 ]]; then
+    safehouse_fail \
+      "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+    return 1
+  fi
+
   if [[ "${#cli_command_exec_args[@]}" -gt 0 ]]; then
     cli_has_command=1
   else
@@ -309,6 +321,29 @@ cli_parse_policy_flag_option() {
         return 1
       fi
       cli_policy_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --always-trust-workdir-config)
+      cli_policy_always_trust_workdir_config=1
+      cli_policy_always_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --always-trust-workdir-config=*)
+      local always_trust_value
+      if policy_value_is_truthy "${current_arg#*=}"; then
+        always_trust_value=1
+      elif policy_value_is_falsey "${current_arg#*=}"; then
+        always_trust_value=0
+      else
+        safehouse_fail \
+          "Invalid value for --always-trust-workdir-config: ${current_arg#*=}" \
+          "Supported values: 1/0, true/false, yes/no, on/off"
+        return 1
+      fi
+      cli_policy_always_trust_workdir_config=$always_trust_value
+      cli_policy_always_trust_workdir_config_set=1
       cli_parse_consumed_args=1
       return 0
       ;;

--- a/bin/lib/cli/parse.sh
+++ b/bin/lib/cli/parse.sh
@@ -20,6 +20,8 @@ cli_policy_workdir_value=""
 cli_policy_trust_workdir_config_set=0
 cli_policy_trust_workdir_config_value=0
 cli_policy_allow_workdir_config_writes=0
+cli_policy_always_trust_workdir_config=0
+cli_policy_always_trust_workdir_config_set=0
 cli_policy_append_profiles=()
 cli_policy_allow_profile_writes=0
 cli_policy_output_path=""
@@ -49,6 +51,8 @@ cli_parse_reset() {
   cli_policy_trust_workdir_config_set=0
   cli_policy_trust_workdir_config_value=0
   cli_policy_allow_workdir_config_writes=0
+  cli_policy_always_trust_workdir_config=0
+  cli_policy_always_trust_workdir_config_set=0
   cli_policy_append_profiles=()
   cli_policy_allow_profile_writes=0
   cli_policy_output_path=""
@@ -215,6 +219,14 @@ cli_finalize_post_parse_state() {
   cli_finalize_runtime_env_inputs || return 1
   cli_finalize_wrapped_command_inputs || return 1
 
+  if [[ "$cli_policy_always_trust_workdir_config" -eq 1 && \
+        "$cli_policy_trust_workdir_config_set" -eq 1 && \
+        "$cli_policy_trust_workdir_config_value" -eq 0 ]]; then
+    safehouse_fail \
+      "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+    return 1
+  fi
+
   if [[ "${#cli_command_exec_args[@]}" -gt 0 ]]; then
     cli_has_command=1
   else
@@ -323,6 +335,29 @@ cli_parse_policy_flag_option() {
       ;;
     --allow-workdir-config-writes)
       cli_policy_allow_workdir_config_writes=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --always-trust-workdir-config)
+      cli_policy_always_trust_workdir_config=1
+      cli_policy_always_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --always-trust-workdir-config=*)
+      local always_trust_value
+      if policy_value_is_truthy "${current_arg#*=}"; then
+        always_trust_value=1
+      elif policy_value_is_falsey "${current_arg#*=}"; then
+        always_trust_value=0
+      else
+        safehouse_fail \
+          "Invalid value for --always-trust-workdir-config: ${current_arg#*=}" \
+          "Supported values: 1/0, true/false, yes/no, on/off"
+        return 1
+      fi
+      cli_policy_always_trust_workdir_config=$always_trust_value
+      cli_policy_always_trust_workdir_config_set=1
       cli_parse_consumed_args=1
       return 0
       ;;

--- a/bin/lib/policy/explain.sh
+++ b/bin/lib/policy/explain.sh
@@ -70,7 +70,7 @@ policy_explain_prepare_runtime_debug_environment() {
 
 policy_explain_print_summary() {
   local workdir_status config_status keychain_status exec_env_status env_pass_names_status profile_env_defaults_status
-  local git_worktree_common_dir_status git_worktree_paths_status
+  local git_worktree_common_dir_status git_worktree_paths_status trusted_workdirs_status trust_source_display
   local idx profile reason
   local host_command_matches execution_command_matches execution_path shell_wrapper_note runtime_debug_env_available=0
 
@@ -156,6 +156,27 @@ policy_explain_print_summary() {
     execution_command_matches="$(policy_explain_path_matches "${policy_req_invoked_command_path}" "$execution_path")"
   fi
 
+  if [[ "${#policy_req_trusted_workdirs[@]}" -gt 0 ]]; then
+    trusted_workdirs_status="$(safehouse_join_by_space "${policy_req_trusted_workdirs[@]}")"
+  else
+    trusted_workdirs_status="$(safehouse_join_by_space)"
+  fi
+
+  case "${policy_req_trust_workdir_config_source:-default}" in
+    --always-trust-workdir-config)
+      trust_source_display="--always-trust-workdir-config (persisted to ${policy_req_trusted_workdirs_path})"
+      ;;
+    --trust-workdir-config)
+      trust_source_display="--trust-workdir-config (this session only)"
+      ;;
+    trusted-workdirs)
+      trust_source_display="${policy_req_trusted_workdirs_path}"
+      ;;
+    *)
+      trust_source_display="${policy_req_trust_workdir_config_source:-default}"
+      ;;
+  esac
+
   shell_wrapper_note=""
   if [[ -n "${policy_req_invoked_command_path:-}" && "${policy_req_invoked_command_path}" != */* ]]; then
     shell_wrapper_note="interactive-shell aliases/functions are not introspected; run \`type -a ${policy_req_invoked_command_path}\` in your shell if wrapper resolution may matter"
@@ -164,7 +185,8 @@ policy_explain_print_summary() {
   {
     echo "safehouse explain:"
     echo "  effective workdir: ${workdir_status} (source: ${policy_req_effective_workdir_source:-unknown})"
-    echo "  workdir config trust: $([[ "$policy_req_trust_workdir_config" -eq 1 ]] && echo "enabled" || echo "disabled") (source: ${policy_req_trust_workdir_config_source})"
+    echo "  trusted workdirs: ${trusted_workdirs_status}"
+    echo "  workdir config trust: $([[ "$policy_req_trust_workdir_config" -eq 1 ]] && echo "enabled" || echo "disabled") (source: ${trust_source_display})"
     echo "  workdir config: ${config_status}"
     echo "  git worktree common dir grant: ${git_worktree_common_dir_status}"
     echo "  git linked worktree read grants: ${git_worktree_paths_status}"

--- a/bin/lib/policy/explain.sh
+++ b/bin/lib/policy/explain.sh
@@ -70,7 +70,7 @@ policy_explain_prepare_runtime_debug_environment() {
 
 policy_explain_print_summary() {
   local workdir_status config_status keychain_status exec_env_status env_pass_names_status profile_env_defaults_status
-  local git_worktree_common_dir_status git_worktree_paths_status trusted_workdirs_status trust_source_display
+  local git_worktree_common_dir_status git_worktree_paths_status trust_source_display
   local idx profile reason
   local host_command_matches execution_command_matches execution_path shell_wrapper_note runtime_debug_env_available=0
 
@@ -154,12 +154,6 @@ policy_explain_print_summary() {
     runtime_debug_env_available=1
     execution_path="$(policy_explain_env_array_value runtime_execution_environment PATH || safehouse_join_by_space)"
     execution_command_matches="$(policy_explain_path_matches "${policy_req_invoked_command_path}" "$execution_path")"
-  fi
-
-  if [[ "${#policy_req_trusted_workdirs[@]}" -gt 0 ]]; then
-    trusted_workdirs_status="$(safehouse_join_by_space "${policy_req_trusted_workdirs[@]}")"
-  else
-    trusted_workdirs_status="$(safehouse_join_by_space)"
   fi
 
   case "${policy_req_trust_workdir_config_source:-default}" in

--- a/bin/lib/policy/explain.sh
+++ b/bin/lib/policy/explain.sh
@@ -70,7 +70,7 @@ policy_explain_prepare_runtime_debug_environment() {
 
 policy_explain_print_summary() {
   local workdir_status config_status keychain_status exec_env_status env_pass_names_status profile_env_defaults_status
-  local git_worktree_common_dir_status git_worktree_paths_status
+  local git_worktree_common_dir_status git_worktree_paths_status trusted_workdirs_status trust_source_display
   local idx profile reason
   local host_command_matches execution_command_matches execution_path shell_wrapper_note runtime_debug_env_available=0
 
@@ -156,6 +156,27 @@ policy_explain_print_summary() {
     execution_command_matches="$(policy_explain_path_matches "${policy_req_invoked_command_path}" "$execution_path")"
   fi
 
+  if [[ "${#policy_req_trusted_workdirs[@]}" -gt 0 ]]; then
+    trusted_workdirs_status="$(safehouse_join_by_space "${policy_req_trusted_workdirs[@]}")"
+  else
+    trusted_workdirs_status="$(safehouse_join_by_space)"
+  fi
+
+  case "${policy_req_trust_workdir_config_source:-default}" in
+    --always-trust-workdir-config)
+      trust_source_display="--always-trust-workdir-config (persisted to ${policy_req_trusted_workdirs_path})"
+      ;;
+    --trust-workdir-config)
+      trust_source_display="--trust-workdir-config (this session only)"
+      ;;
+    trusted-workdirs)
+      trust_source_display="${policy_req_trusted_workdirs_path}"
+      ;;
+    *)
+      trust_source_display="${policy_req_trust_workdir_config_source:-default}"
+      ;;
+  esac
+
   shell_wrapper_note=""
   if [[ -n "${policy_req_invoked_command_path:-}" && "${policy_req_invoked_command_path}" != */* ]]; then
     shell_wrapper_note="interactive-shell aliases/functions are not introspected; run \`type -a ${policy_req_invoked_command_path}\` in your shell if wrapper resolution may matter"
@@ -164,7 +185,7 @@ policy_explain_print_summary() {
   {
     echo "safehouse explain:"
     echo "  effective workdir: ${workdir_status} (source: ${policy_req_effective_workdir_source:-unknown})"
-    echo "  workdir config trust: $([[ "$policy_req_trust_workdir_config" -eq 1 ]] && echo "enabled" || echo "disabled") (source: ${policy_req_trust_workdir_config_source})"
+    echo "  workdir config trust: $([[ "$policy_req_trust_workdir_config" -eq 1 ]] && echo "enabled" || echo "disabled") (source: ${trust_source_display})"
     echo "  workdir config: ${config_status}"
     echo "  git worktree common dir grant: ${git_worktree_common_dir_status}"
     echo "  git linked worktree read grants: ${git_worktree_paths_status}"

--- a/bin/lib/policy/request.sh
+++ b/bin/lib/policy/request.sh
@@ -25,6 +25,9 @@ policy_req_git_worktree_common_dir=""
 policy_req_git_linked_worktree_paths=()
 policy_req_trust_workdir_config=0
 policy_req_trust_workdir_config_source="default"
+policy_req_trusted_workdirs_path=""
+policy_req_trusted_workdirs_loaded=0
+policy_req_trusted_workdirs=()
 policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
@@ -162,6 +165,9 @@ policy_request_reset() {
   policy_req_git_linked_worktree_paths=()
   policy_req_trust_workdir_config=0
   policy_req_trust_workdir_config_source="default"
+  policy_req_trusted_workdirs_path=""
+  policy_req_trusted_workdirs_loaded=0
+  safehouse_array_clear policy_req_trusted_workdirs
   policy_req_workdir_config_path=""
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
@@ -235,15 +241,92 @@ policy_request_collect_env_add_dir_inputs() {
   fi
 }
 
+policy_request_load_trusted_workdirs() {
+  local line trimmed
+
+  policy_req_trusted_workdirs_path="${HOME}/${safehouse_trusted_workdirs_config_relpath}"
+  safehouse_array_clear policy_req_trusted_workdirs
+
+  if [[ ! -f "$policy_req_trusted_workdirs_path" ]]; then
+    policy_req_trusted_workdirs_loaded=0
+    return 0
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    trimmed="$(safehouse_trim_whitespace "$line")"
+    [[ -n "$trimmed" ]] || continue
+    [[ "${trimmed:0:1}" == "#" ]] && continue
+    policy_req_trusted_workdirs+=("$trimmed")
+  done < "$policy_req_trusted_workdirs_path"
+
+  policy_req_trusted_workdirs_loaded=1
+}
+
+policy_request_write_always_trust_workdir() {
+  local trusted_file parent_dir line existing_line
+
+  [[ -n "$policy_req_effective_workdir" ]] || return 0
+
+  trusted_file="${policy_req_trusted_workdirs_path}"
+
+  if [[ -f "$trusted_file" ]]; then
+    while IFS= read -r existing_line || [[ -n "$existing_line" ]]; do
+      if [[ "$existing_line" == "$policy_req_effective_workdir" ]]; then
+        return 0
+      fi
+    done < "$trusted_file"
+  fi
+
+  parent_dir="$(dirname "$trusted_file")"
+  mkdir -p "$parent_dir" || return 1
+  printf '%s\n' "$policy_req_effective_workdir" >> "$trusted_file" || return 1
+}
+
+policy_request_remove_always_trust_workdir() {
+  local trusted_file tmp_file line
+
+  trusted_file="${policy_req_trusted_workdirs_path}"
+  [[ -f "$trusted_file" ]] || return 0
+
+  tmp_file="${trusted_file}.tmp.$$"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" != "$policy_req_effective_workdir" ]]; then
+      printf '%s\n' "$line"
+    fi
+  done < "$trusted_file" > "$tmp_file" || { rm -f "$tmp_file"; return 1; }
+  mv "$tmp_file" "$trusted_file" || return 1
+}
+
 policy_request_resolve_trust_workdir_config() {
   local env_trust_value=""
 
+  # --always-trust-workdir-config=true: write to file AND trust this session
+  if [[ "$cli_policy_always_trust_workdir_config" -eq 1 ]]; then
+    policy_request_write_always_trust_workdir || return 1
+    policy_req_trust_workdir_config=1
+    policy_req_trust_workdir_config_source="--always-trust-workdir-config"
+    return 0
+  fi
+
+  # --always-trust-workdir-config=false: remove from file, also purge in-memory list
+  if [[ "$cli_policy_always_trust_workdir_config_set" -eq 1 && "$cli_policy_always_trust_workdir_config" -eq 0 ]]; then
+    policy_request_remove_always_trust_workdir || return 1
+    local -a filtered_trusted=()
+    local tw
+    for tw in "${policy_req_trusted_workdirs[@]+"${policy_req_trusted_workdirs[@]}"}"; do
+      [[ "$tw" == "$policy_req_effective_workdir" ]] || filtered_trusted+=("$tw")
+    done
+    policy_req_trusted_workdirs=("${filtered_trusted[@]+"${filtered_trusted[@]}"}")
+  fi
+
+  # CLI --trust-workdir-config takes next highest precedence
   if [[ "$cli_policy_trust_workdir_config_set" -eq 1 ]]; then
     policy_req_trust_workdir_config="$cli_policy_trust_workdir_config_value"
     policy_req_trust_workdir_config_source="--trust-workdir-config"
     return 0
   fi
 
+  # SAFEHOUSE_TRUST_WORKDIR_CONFIG env var
   if [[ "${SAFEHOUSE_TRUST_WORKDIR_CONFIG+x}" == "x" ]]; then
     env_trust_value="${SAFEHOUSE_TRUST_WORKDIR_CONFIG}"
     if policy_value_is_truthy "$env_trust_value"; then
@@ -258,6 +341,18 @@ policy_request_resolve_trust_workdir_config() {
     fi
     policy_req_trust_workdir_config_source="SAFEHOUSE_TRUST_WORKDIR_CONFIG"
     return 0
+  fi
+
+  # Check trusted-workdirs file
+  if [[ "${#policy_req_trusted_workdirs[@]}" -gt 0 && -n "$policy_req_effective_workdir" ]]; then
+    local trusted_workdir
+    for trusted_workdir in "${policy_req_trusted_workdirs[@]}"; do
+      if [[ "$trusted_workdir" == "$policy_req_effective_workdir" ]]; then
+        policy_req_trust_workdir_config=1
+        policy_req_trust_workdir_config_source="trusted-workdirs"
+        return 0
+      fi
+    done
   fi
 
   policy_req_trust_workdir_config=0
@@ -477,8 +572,9 @@ policy_request_build() {
   policy_request_collect_env_add_dir_inputs env_add_dirs_ro_inputs env_add_dirs_rw_inputs || return 1
   safehouse_array_copy cli_add_dirs_ro_inputs cli_policy_add_dirs_ro_values
   safehouse_array_copy cli_add_dirs_rw_inputs cli_policy_add_dirs_rw_values
-  policy_request_resolve_trust_workdir_config || return 1
+  policy_request_load_trusted_workdirs || return 1
   policy_request_resolve_effective_workdir || return 1
+  policy_request_resolve_trust_workdir_config || return 1
   policy_request_resolve_effective_workdir_git_root || return 1
   policy_request_resolve_git_worktree_common_dir_access || return 1
   policy_request_resolve_git_linked_worktree_access || return 1

--- a/bin/lib/policy/request.sh
+++ b/bin/lib/policy/request.sh
@@ -25,6 +25,9 @@ policy_req_git_worktree_common_dir=""
 policy_req_git_linked_worktree_paths=()
 policy_req_trust_workdir_config=0
 policy_req_trust_workdir_config_source="default"
+policy_req_trusted_workdirs_path=""
+policy_req_trusted_workdirs_loaded=0
+policy_req_trusted_workdirs=()
 policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
@@ -184,6 +187,9 @@ policy_request_reset() {
   policy_req_git_linked_worktree_paths=()
   policy_req_trust_workdir_config=0
   policy_req_trust_workdir_config_source="default"
+  policy_req_trusted_workdirs_path=""
+  policy_req_trusted_workdirs_loaded=0
+  safehouse_array_clear policy_req_trusted_workdirs
   policy_req_workdir_config_path=""
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
@@ -260,15 +266,120 @@ policy_request_collect_env_add_dir_inputs() {
   fi
 }
 
+# Trim a trusted-workdirs line and, when it points at an existing directory,
+# canonicalize it with safehouse_normalize_abs_path so comparisons survive
+# macOS path aliases (e.g. /var/... vs /private/var/...). Blank/comment lines
+# and entries whose directory does not exist are returned trimmed but unchanged.
+policy_request_canonicalize_trusted_workdir_entry() {
+  local entry trimmed
+
+  entry="$1"
+  trimmed="$(safehouse_trim_whitespace "$entry")"
+  if [[ -n "$trimmed" && -d "$trimmed" ]]; then
+    safehouse_normalize_abs_path "$trimmed" || return 1
+    return 0
+  fi
+  printf '%s\n' "$trimmed"
+}
+
+policy_request_load_trusted_workdirs() {
+  local line trimmed canonical
+
+  policy_req_trusted_workdirs_path="${HOME}/${safehouse_trusted_workdirs_config_relpath}"
+  safehouse_array_clear policy_req_trusted_workdirs
+  policy_req_trusted_workdirs_loaded=0
+
+  if [[ ! -e "$policy_req_trusted_workdirs_path" ]]; then
+    return 0
+  fi
+  if [[ ! -f "$policy_req_trusted_workdirs_path" ]]; then
+    safehouse_fail "Trusted workdirs path exists but is not a regular file: $policy_req_trusted_workdirs_path"
+    return 1
+  fi
+  if [[ ! -r "$policy_req_trusted_workdirs_path" ]]; then
+    safehouse_fail "Trusted workdirs file is not readable: $policy_req_trusted_workdirs_path"
+    return 1
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    trimmed="$(safehouse_trim_whitespace "$line")"
+    [[ -n "$trimmed" ]] || continue
+    [[ "${trimmed:0:1}" == "#" ]] && continue
+    canonical="$(policy_request_canonicalize_trusted_workdir_entry "$trimmed")" || return 1
+    [[ -n "$canonical" ]] || continue
+    policy_req_trusted_workdirs+=("$canonical")
+  done < "$policy_req_trusted_workdirs_path"
+
+  policy_req_trusted_workdirs_loaded=1
+}
+
+policy_request_write_always_trust_workdir() {
+  local trusted_file parent_dir existing_line existing_canonical
+
+  [[ -n "$policy_req_effective_workdir" ]] || return 0
+
+  trusted_file="${policy_req_trusted_workdirs_path}"
+
+  if [[ -f "$trusted_file" ]]; then
+    while IFS= read -r existing_line || [[ -n "$existing_line" ]]; do
+      existing_canonical="$(policy_request_canonicalize_trusted_workdir_entry "$existing_line")" || return 1
+      if [[ "$existing_canonical" == "$policy_req_effective_workdir" ]]; then
+        return 0
+      fi
+    done < "$trusted_file"
+  fi
+
+  parent_dir="$(dirname "$trusted_file")"
+  mkdir -p "$parent_dir" || return 1
+  printf '%s\n' "$policy_req_effective_workdir" >> "$trusted_file" || return 1
+}
+
+policy_request_remove_always_trust_workdir() {
+  local trusted_file tmp_file line canonical
+
+  trusted_file="${policy_req_trusted_workdirs_path}"
+  [[ -f "$trusted_file" ]] || return 0
+
+  tmp_file="${trusted_file}.tmp.$$"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    canonical="$(policy_request_canonicalize_trusted_workdir_entry "$line")" || { rm -f "$tmp_file"; return 1; }
+    if [[ "$canonical" != "$policy_req_effective_workdir" ]]; then
+      printf '%s\n' "$line"
+    fi
+  done < "$trusted_file" > "$tmp_file" || { rm -f "$tmp_file"; return 1; }
+  mv "$tmp_file" "$trusted_file" || return 1
+}
+
 policy_request_resolve_trust_workdir_config() {
   local env_trust_value=""
 
+  # --always-trust-workdir-config=true: write to file AND trust this session
+  if [[ "$cli_policy_always_trust_workdir_config" -eq 1 ]]; then
+    policy_request_write_always_trust_workdir || return 1
+    policy_req_trust_workdir_config=1
+    policy_req_trust_workdir_config_source="--always-trust-workdir-config"
+    return 0
+  fi
+
+  # --always-trust-workdir-config=false: remove from file, also purge in-memory list
+  if [[ "$cli_policy_always_trust_workdir_config_set" -eq 1 && "$cli_policy_always_trust_workdir_config" -eq 0 ]]; then
+    policy_request_remove_always_trust_workdir || return 1
+    local -a filtered_trusted=()
+    local tw
+    for tw in "${policy_req_trusted_workdirs[@]+"${policy_req_trusted_workdirs[@]}"}"; do
+      [[ "$tw" == "$policy_req_effective_workdir" ]] || filtered_trusted+=("$tw")
+    done
+    policy_req_trusted_workdirs=("${filtered_trusted[@]+"${filtered_trusted[@]}"}")
+  fi
+
+  # CLI --trust-workdir-config takes next highest precedence
   if [[ "$cli_policy_trust_workdir_config_set" -eq 1 ]]; then
     policy_req_trust_workdir_config="$cli_policy_trust_workdir_config_value"
     policy_req_trust_workdir_config_source="--trust-workdir-config"
     return 0
   fi
 
+  # SAFEHOUSE_TRUST_WORKDIR_CONFIG env var
   if [[ "${SAFEHOUSE_TRUST_WORKDIR_CONFIG+x}" == "x" ]]; then
     env_trust_value="${SAFEHOUSE_TRUST_WORKDIR_CONFIG}"
     if policy_value_is_truthy "$env_trust_value"; then
@@ -283,6 +394,18 @@ policy_request_resolve_trust_workdir_config() {
     fi
     policy_req_trust_workdir_config_source="SAFEHOUSE_TRUST_WORKDIR_CONFIG"
     return 0
+  fi
+
+  # Check trusted-workdirs file
+  if [[ "${#policy_req_trusted_workdirs[@]}" -gt 0 && -n "$policy_req_effective_workdir" ]]; then
+    local trusted_workdir
+    for trusted_workdir in "${policy_req_trusted_workdirs[@]}"; do
+      if [[ "$trusted_workdir" == "$policy_req_effective_workdir" ]]; then
+        policy_req_trust_workdir_config=1
+        policy_req_trust_workdir_config_source="trusted-workdirs"
+        return 0
+      fi
+    done
   fi
 
   policy_req_trust_workdir_config=0
@@ -531,8 +654,9 @@ policy_request_build() {
   policy_request_collect_env_add_dir_inputs env_add_dirs_ro_inputs env_add_dirs_rw_inputs || return 1
   safehouse_array_copy cli_add_dirs_ro_inputs cli_policy_add_dirs_ro_values
   safehouse_array_copy cli_add_dirs_rw_inputs cli_policy_add_dirs_rw_values
-  policy_request_resolve_trust_workdir_config || return 1
+  policy_request_load_trusted_workdirs || return 1
   policy_request_resolve_effective_workdir || return 1
+  policy_request_resolve_trust_workdir_config || return 1
   policy_request_resolve_effective_workdir_git_root || return 1
   policy_request_resolve_git_worktree_common_dir_access || return 1
   policy_request_resolve_git_linked_worktree_access || return 1

--- a/bin/lib/policy/request.sh
+++ b/bin/lib/policy/request.sh
@@ -341,6 +341,7 @@ policy_request_remove_always_trust_workdir() {
   [[ -f "$trusted_file" ]] || return 0
 
   tmp_file="${trusted_file}.tmp.$$"
+  # shellcheck disable=SC2094  # input $trusted_file and output $tmp_file are always distinct files
   while IFS= read -r line || [[ -n "$line" ]]; do
     canonical="$(policy_request_canonicalize_trusted_workdir_entry "$line")" || { rm -f "$tmp_file"; return 1; }
     if [[ "$canonical" != "$policy_req_effective_workdir" ]]; then

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -2698,6 +2698,7 @@ safehouse_project_github_url="https://github.com/eugene1g/agent-safehouse"
 safehouse_project_release_asset_url="${safehouse_project_github_url}/releases/latest/download/safehouse.sh"
 safehouse_project_head_asset_url="https://raw.githubusercontent.com/eugene1g/agent-safehouse/main/dist/safehouse.sh"
 safehouse_workdir_config_filename=".safehouse"
+safehouse_trusted_workdirs_config_relpath=".config/safehouse/trusted-workdirs"
 
 resolve_safehouse_project_version() {
   local version=""
@@ -4147,6 +4148,9 @@ policy_req_git_worktree_common_dir=""
 policy_req_git_linked_worktree_paths=()
 policy_req_trust_workdir_config=0
 policy_req_trust_workdir_config_source="default"
+policy_req_trusted_workdirs_path=""
+policy_req_trusted_workdirs_loaded=0
+policy_req_trusted_workdirs=()
 policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
@@ -4284,6 +4288,9 @@ policy_request_reset() {
   policy_req_git_linked_worktree_paths=()
   policy_req_trust_workdir_config=0
   policy_req_trust_workdir_config_source="default"
+  policy_req_trusted_workdirs_path=""
+  policy_req_trusted_workdirs_loaded=0
+  safehouse_array_clear policy_req_trusted_workdirs
   policy_req_workdir_config_path=""
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
@@ -4357,15 +4364,92 @@ policy_request_collect_env_add_dir_inputs() {
   fi
 }
 
+policy_request_load_trusted_workdirs() {
+  local line trimmed
+
+  policy_req_trusted_workdirs_path="${HOME}/${safehouse_trusted_workdirs_config_relpath}"
+  safehouse_array_clear policy_req_trusted_workdirs
+
+  if [[ ! -f "$policy_req_trusted_workdirs_path" ]]; then
+    policy_req_trusted_workdirs_loaded=0
+    return 0
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    trimmed="$(safehouse_trim_whitespace "$line")"
+    [[ -n "$trimmed" ]] || continue
+    [[ "${trimmed:0:1}" == "#" ]] && continue
+    policy_req_trusted_workdirs+=("$trimmed")
+  done < "$policy_req_trusted_workdirs_path"
+
+  policy_req_trusted_workdirs_loaded=1
+}
+
+policy_request_write_always_trust_workdir() {
+  local trusted_file parent_dir line existing_line
+
+  [[ -n "$policy_req_effective_workdir" ]] || return 0
+
+  trusted_file="${policy_req_trusted_workdirs_path}"
+
+  if [[ -f "$trusted_file" ]]; then
+    while IFS= read -r existing_line || [[ -n "$existing_line" ]]; do
+      if [[ "$existing_line" == "$policy_req_effective_workdir" ]]; then
+        return 0
+      fi
+    done < "$trusted_file"
+  fi
+
+  parent_dir="$(dirname "$trusted_file")"
+  mkdir -p "$parent_dir" || return 1
+  printf '%s\n' "$policy_req_effective_workdir" >> "$trusted_file" || return 1
+}
+
+policy_request_remove_always_trust_workdir() {
+  local trusted_file tmp_file line
+
+  trusted_file="${policy_req_trusted_workdirs_path}"
+  [[ -f "$trusted_file" ]] || return 0
+
+  tmp_file="${trusted_file}.tmp.$$"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" != "$policy_req_effective_workdir" ]]; then
+      printf '%s\n' "$line"
+    fi
+  done < "$trusted_file" > "$tmp_file" || { rm -f "$tmp_file"; return 1; }
+  mv "$tmp_file" "$trusted_file" || return 1
+}
+
 policy_request_resolve_trust_workdir_config() {
   local env_trust_value=""
 
+  # --always-trust-workdir-config=true: write to file AND trust this session
+  if [[ "$cli_policy_always_trust_workdir_config" -eq 1 ]]; then
+    policy_request_write_always_trust_workdir || return 1
+    policy_req_trust_workdir_config=1
+    policy_req_trust_workdir_config_source="--always-trust-workdir-config"
+    return 0
+  fi
+
+  # --always-trust-workdir-config=false: remove from file, also purge in-memory list
+  if [[ "$cli_policy_always_trust_workdir_config_set" -eq 1 && "$cli_policy_always_trust_workdir_config" -eq 0 ]]; then
+    policy_request_remove_always_trust_workdir || return 1
+    local -a filtered_trusted=()
+    local tw
+    for tw in "${policy_req_trusted_workdirs[@]+"${policy_req_trusted_workdirs[@]}"}"; do
+      [[ "$tw" == "$policy_req_effective_workdir" ]] || filtered_trusted+=("$tw")
+    done
+    policy_req_trusted_workdirs=("${filtered_trusted[@]+"${filtered_trusted[@]}"}")
+  fi
+
+  # CLI --trust-workdir-config takes next highest precedence
   if [[ "$cli_policy_trust_workdir_config_set" -eq 1 ]]; then
     policy_req_trust_workdir_config="$cli_policy_trust_workdir_config_value"
     policy_req_trust_workdir_config_source="--trust-workdir-config"
     return 0
   fi
 
+  # SAFEHOUSE_TRUST_WORKDIR_CONFIG env var
   if [[ "${SAFEHOUSE_TRUST_WORKDIR_CONFIG+x}" == "x" ]]; then
     env_trust_value="${SAFEHOUSE_TRUST_WORKDIR_CONFIG}"
     if policy_value_is_truthy "$env_trust_value"; then
@@ -4380,6 +4464,18 @@ policy_request_resolve_trust_workdir_config() {
     fi
     policy_req_trust_workdir_config_source="SAFEHOUSE_TRUST_WORKDIR_CONFIG"
     return 0
+  fi
+
+  # Check trusted-workdirs file
+  if [[ "${#policy_req_trusted_workdirs[@]}" -gt 0 && -n "$policy_req_effective_workdir" ]]; then
+    local trusted_workdir
+    for trusted_workdir in "${policy_req_trusted_workdirs[@]}"; do
+      if [[ "$trusted_workdir" == "$policy_req_effective_workdir" ]]; then
+        policy_req_trust_workdir_config=1
+        policy_req_trust_workdir_config_source="trusted-workdirs"
+        return 0
+      fi
+    done
   fi
 
   policy_req_trust_workdir_config=0
@@ -4599,8 +4695,9 @@ policy_request_build() {
   policy_request_collect_env_add_dir_inputs env_add_dirs_ro_inputs env_add_dirs_rw_inputs || return 1
   safehouse_array_copy cli_add_dirs_ro_inputs cli_policy_add_dirs_ro_values
   safehouse_array_copy cli_add_dirs_rw_inputs cli_policy_add_dirs_rw_values
-  policy_request_resolve_trust_workdir_config || return 1
+  policy_request_load_trusted_workdirs || return 1
   policy_request_resolve_effective_workdir || return 1
+  policy_request_resolve_trust_workdir_config || return 1
   policy_request_resolve_effective_workdir_git_root || return 1
   policy_request_resolve_git_worktree_common_dir_access || return 1
   policy_request_resolve_git_linked_worktree_access || return 1
@@ -5937,7 +6034,7 @@ policy_explain_prepare_runtime_debug_environment() {
 
 policy_explain_print_summary() {
   local workdir_status config_status keychain_status exec_env_status env_pass_names_status profile_env_defaults_status
-  local git_worktree_common_dir_status git_worktree_paths_status
+  local git_worktree_common_dir_status git_worktree_paths_status trusted_workdirs_status trust_source_display
   local idx profile reason
   local host_command_matches execution_command_matches execution_path shell_wrapper_note runtime_debug_env_available=0
 
@@ -6023,6 +6120,27 @@ policy_explain_print_summary() {
     execution_command_matches="$(policy_explain_path_matches "${policy_req_invoked_command_path}" "$execution_path")"
   fi
 
+  if [[ "${#policy_req_trusted_workdirs[@]}" -gt 0 ]]; then
+    trusted_workdirs_status="$(safehouse_join_by_space "${policy_req_trusted_workdirs[@]}")"
+  else
+    trusted_workdirs_status="$(safehouse_join_by_space)"
+  fi
+
+  case "${policy_req_trust_workdir_config_source:-default}" in
+    --always-trust-workdir-config)
+      trust_source_display="--always-trust-workdir-config (persisted to ${policy_req_trusted_workdirs_path})"
+      ;;
+    --trust-workdir-config)
+      trust_source_display="--trust-workdir-config (this session only)"
+      ;;
+    trusted-workdirs)
+      trust_source_display="${policy_req_trusted_workdirs_path}"
+      ;;
+    *)
+      trust_source_display="${policy_req_trust_workdir_config_source:-default}"
+      ;;
+  esac
+
   shell_wrapper_note=""
   if [[ -n "${policy_req_invoked_command_path:-}" && "${policy_req_invoked_command_path}" != */* ]]; then
     shell_wrapper_note="interactive-shell aliases/functions are not introspected; run \`type -a ${policy_req_invoked_command_path}\` in your shell if wrapper resolution may matter"
@@ -6031,7 +6149,8 @@ policy_explain_print_summary() {
   {
     echo "safehouse explain:"
     echo "  effective workdir: ${workdir_status} (source: ${policy_req_effective_workdir_source:-unknown})"
-    echo "  workdir config trust: $([[ "$policy_req_trust_workdir_config" -eq 1 ]] && echo "enabled" || echo "disabled") (source: ${policy_req_trust_workdir_config_source})"
+    echo "  trusted workdirs: ${trusted_workdirs_status}"
+    echo "  workdir config trust: $([[ "$policy_req_trust_workdir_config" -eq 1 ]] && echo "enabled" || echo "disabled") (source: ${trust_source_display})"
     echo "  workdir config: ${config_status}"
     echo "  git worktree common dir grant: ${git_worktree_common_dir_status}"
     echo "  git linked worktree read grants: ${git_worktree_paths_status}"
@@ -7376,6 +7495,13 @@ Policy scope options:
   --trust-workdir-config=BOOL
       Trust and load <workdir>/.safehouse (default: disabled)
 
+  --always-trust-workdir-config
+  --always-trust-workdir-config=BOOL
+      Save workdir to ~/.config/safehouse/trusted-workdirs and trust it for this
+      invocation. Future invocations in this directory will automatically load
+      <workdir>/.safehouse without needing this flag again.
+      Conflicts with --trust-workdir-config=false/0/no/off (contradictory).
+
   --append-profile PATH
   --append-profile=PATH
       Append an additional sandbox profile file after generated rules
@@ -7429,6 +7555,10 @@ Config file:
       Supports keys:
         add-dirs-ro=PATHS
         add-dirs=PATHS
+
+  ~/.config/safehouse/trusted-workdirs (optional, always read)
+      One trusted directory path per line; blank lines and # comments allowed
+      Written by --always-trust-workdir-config; edit directly to remove entries
 USAGE
 }
 
@@ -7453,6 +7583,8 @@ cli_policy_workdir_set=0
 cli_policy_workdir_value=""
 cli_policy_trust_workdir_config_set=0
 cli_policy_trust_workdir_config_value=0
+cli_policy_always_trust_workdir_config=0
+cli_policy_always_trust_workdir_config_set=0
 cli_policy_append_profiles=()
 cli_policy_output_path=""
 cli_policy_output_path_set=0
@@ -7480,6 +7612,8 @@ cli_parse_reset() {
   cli_policy_workdir_value=""
   cli_policy_trust_workdir_config_set=0
   cli_policy_trust_workdir_config_value=0
+  cli_policy_always_trust_workdir_config=0
+  cli_policy_always_trust_workdir_config_set=0
   cli_policy_append_profiles=()
   cli_policy_output_path=""
   cli_policy_output_path_set=0
@@ -7645,6 +7779,14 @@ cli_finalize_post_parse_state() {
   cli_finalize_runtime_env_inputs || return 1
   cli_finalize_wrapped_command_inputs || return 1
 
+  if [[ "$cli_policy_always_trust_workdir_config" -eq 1 && \
+        "$cli_policy_trust_workdir_config_set" -eq 1 && \
+        "$cli_policy_trust_workdir_config_value" -eq 0 ]]; then
+    safehouse_fail \
+      "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+    return 1
+  fi
+
   if [[ "${#cli_command_exec_args[@]}" -gt 0 ]]; then
     cli_has_command=1
   else
@@ -7743,6 +7885,29 @@ cli_parse_policy_flag_option() {
         return 1
       fi
       cli_policy_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --always-trust-workdir-config)
+      cli_policy_always_trust_workdir_config=1
+      cli_policy_always_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --always-trust-workdir-config=*)
+      local always_trust_value
+      if policy_value_is_truthy "${current_arg#*=}"; then
+        always_trust_value=1
+      elif policy_value_is_falsey "${current_arg#*=}"; then
+        always_trust_value=0
+      else
+        safehouse_fail \
+          "Invalid value for --always-trust-workdir-config: ${current_arg#*=}" \
+          "Supported values: 1/0, true/false, yes/no, on/off"
+        return 1
+      fi
+      cli_policy_always_trust_workdir_config=$always_trust_value
+      cli_policy_always_trust_workdir_config_set=1
       cli_parse_consumed_args=1
       return 0
       ;;

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -2844,6 +2844,7 @@ safehouse_project_github_url="https://github.com/eugene1g/agent-safehouse"
 safehouse_project_release_asset_url="${safehouse_project_github_url}/releases/latest/download/safehouse.sh"
 safehouse_project_head_asset_url="https://raw.githubusercontent.com/eugene1g/agent-safehouse/main/dist/safehouse.sh"
 safehouse_workdir_config_filename=".safehouse"
+safehouse_trusted_workdirs_config_relpath=".config/safehouse/trusted-workdirs"
 
 resolve_safehouse_project_version() {
   local version=""
@@ -4290,6 +4291,9 @@ policy_req_git_worktree_common_dir=""
 policy_req_git_linked_worktree_paths=()
 policy_req_trust_workdir_config=0
 policy_req_trust_workdir_config_source="default"
+policy_req_trusted_workdirs_path=""
+policy_req_trusted_workdirs_loaded=0
+policy_req_trusted_workdirs=()
 policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
@@ -4449,6 +4453,9 @@ policy_request_reset() {
   policy_req_git_linked_worktree_paths=()
   policy_req_trust_workdir_config=0
   policy_req_trust_workdir_config_source="default"
+  policy_req_trusted_workdirs_path=""
+  policy_req_trusted_workdirs_loaded=0
+  safehouse_array_clear policy_req_trusted_workdirs
   policy_req_workdir_config_path=""
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
@@ -4525,15 +4532,120 @@ policy_request_collect_env_add_dir_inputs() {
   fi
 }
 
+# Trim a trusted-workdirs line and, when it points at an existing directory,
+# canonicalize it with safehouse_normalize_abs_path so comparisons survive
+# macOS path aliases (e.g. /var/... vs /private/var/...). Blank/comment lines
+# and entries whose directory does not exist are returned trimmed but unchanged.
+policy_request_canonicalize_trusted_workdir_entry() {
+  local entry trimmed
+
+  entry="$1"
+  trimmed="$(safehouse_trim_whitespace "$entry")"
+  if [[ -n "$trimmed" && -d "$trimmed" ]]; then
+    safehouse_normalize_abs_path "$trimmed" || return 1
+    return 0
+  fi
+  printf '%s\n' "$trimmed"
+}
+
+policy_request_load_trusted_workdirs() {
+  local line trimmed canonical
+
+  policy_req_trusted_workdirs_path="${HOME}/${safehouse_trusted_workdirs_config_relpath}"
+  safehouse_array_clear policy_req_trusted_workdirs
+  policy_req_trusted_workdirs_loaded=0
+
+  if [[ ! -e "$policy_req_trusted_workdirs_path" ]]; then
+    return 0
+  fi
+  if [[ ! -f "$policy_req_trusted_workdirs_path" ]]; then
+    safehouse_fail "Trusted workdirs path exists but is not a regular file: $policy_req_trusted_workdirs_path"
+    return 1
+  fi
+  if [[ ! -r "$policy_req_trusted_workdirs_path" ]]; then
+    safehouse_fail "Trusted workdirs file is not readable: $policy_req_trusted_workdirs_path"
+    return 1
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    trimmed="$(safehouse_trim_whitespace "$line")"
+    [[ -n "$trimmed" ]] || continue
+    [[ "${trimmed:0:1}" == "#" ]] && continue
+    canonical="$(policy_request_canonicalize_trusted_workdir_entry "$trimmed")" || return 1
+    [[ -n "$canonical" ]] || continue
+    policy_req_trusted_workdirs+=("$canonical")
+  done < "$policy_req_trusted_workdirs_path"
+
+  policy_req_trusted_workdirs_loaded=1
+}
+
+policy_request_write_always_trust_workdir() {
+  local trusted_file parent_dir existing_line existing_canonical
+
+  [[ -n "$policy_req_effective_workdir" ]] || return 0
+
+  trusted_file="${policy_req_trusted_workdirs_path}"
+
+  if [[ -f "$trusted_file" ]]; then
+    while IFS= read -r existing_line || [[ -n "$existing_line" ]]; do
+      existing_canonical="$(policy_request_canonicalize_trusted_workdir_entry "$existing_line")" || return 1
+      if [[ "$existing_canonical" == "$policy_req_effective_workdir" ]]; then
+        return 0
+      fi
+    done < "$trusted_file"
+  fi
+
+  parent_dir="$(dirname "$trusted_file")"
+  mkdir -p "$parent_dir" || return 1
+  printf '%s\n' "$policy_req_effective_workdir" >> "$trusted_file" || return 1
+}
+
+policy_request_remove_always_trust_workdir() {
+  local trusted_file tmp_file line canonical
+
+  trusted_file="${policy_req_trusted_workdirs_path}"
+  [[ -f "$trusted_file" ]] || return 0
+
+  tmp_file="${trusted_file}.tmp.$$"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    canonical="$(policy_request_canonicalize_trusted_workdir_entry "$line")" || { rm -f "$tmp_file"; return 1; }
+    if [[ "$canonical" != "$policy_req_effective_workdir" ]]; then
+      printf '%s\n' "$line"
+    fi
+  done < "$trusted_file" > "$tmp_file" || { rm -f "$tmp_file"; return 1; }
+  mv "$tmp_file" "$trusted_file" || return 1
+}
+
 policy_request_resolve_trust_workdir_config() {
   local env_trust_value=""
 
+  # --always-trust-workdir-config=true: write to file AND trust this session
+  if [[ "$cli_policy_always_trust_workdir_config" -eq 1 ]]; then
+    policy_request_write_always_trust_workdir || return 1
+    policy_req_trust_workdir_config=1
+    policy_req_trust_workdir_config_source="--always-trust-workdir-config"
+    return 0
+  fi
+
+  # --always-trust-workdir-config=false: remove from file, also purge in-memory list
+  if [[ "$cli_policy_always_trust_workdir_config_set" -eq 1 && "$cli_policy_always_trust_workdir_config" -eq 0 ]]; then
+    policy_request_remove_always_trust_workdir || return 1
+    local -a filtered_trusted=()
+    local tw
+    for tw in "${policy_req_trusted_workdirs[@]+"${policy_req_trusted_workdirs[@]}"}"; do
+      [[ "$tw" == "$policy_req_effective_workdir" ]] || filtered_trusted+=("$tw")
+    done
+    policy_req_trusted_workdirs=("${filtered_trusted[@]+"${filtered_trusted[@]}"}")
+  fi
+
+  # CLI --trust-workdir-config takes next highest precedence
   if [[ "$cli_policy_trust_workdir_config_set" -eq 1 ]]; then
     policy_req_trust_workdir_config="$cli_policy_trust_workdir_config_value"
     policy_req_trust_workdir_config_source="--trust-workdir-config"
     return 0
   fi
 
+  # SAFEHOUSE_TRUST_WORKDIR_CONFIG env var
   if [[ "${SAFEHOUSE_TRUST_WORKDIR_CONFIG+x}" == "x" ]]; then
     env_trust_value="${SAFEHOUSE_TRUST_WORKDIR_CONFIG}"
     if policy_value_is_truthy "$env_trust_value"; then
@@ -4548,6 +4660,18 @@ policy_request_resolve_trust_workdir_config() {
     fi
     policy_req_trust_workdir_config_source="SAFEHOUSE_TRUST_WORKDIR_CONFIG"
     return 0
+  fi
+
+  # Check trusted-workdirs file
+  if [[ "${#policy_req_trusted_workdirs[@]}" -gt 0 && -n "$policy_req_effective_workdir" ]]; then
+    local trusted_workdir
+    for trusted_workdir in "${policy_req_trusted_workdirs[@]}"; do
+      if [[ "$trusted_workdir" == "$policy_req_effective_workdir" ]]; then
+        policy_req_trust_workdir_config=1
+        policy_req_trust_workdir_config_source="trusted-workdirs"
+        return 0
+      fi
+    done
   fi
 
   policy_req_trust_workdir_config=0
@@ -4796,8 +4920,9 @@ policy_request_build() {
   policy_request_collect_env_add_dir_inputs env_add_dirs_ro_inputs env_add_dirs_rw_inputs || return 1
   safehouse_array_copy cli_add_dirs_ro_inputs cli_policy_add_dirs_ro_values
   safehouse_array_copy cli_add_dirs_rw_inputs cli_policy_add_dirs_rw_values
-  policy_request_resolve_trust_workdir_config || return 1
+  policy_request_load_trusted_workdirs || return 1
   policy_request_resolve_effective_workdir || return 1
+  policy_request_resolve_trust_workdir_config || return 1
   policy_request_resolve_effective_workdir_git_root || return 1
   policy_request_resolve_git_worktree_common_dir_access || return 1
   policy_request_resolve_git_linked_worktree_access || return 1
@@ -6206,7 +6331,7 @@ policy_explain_prepare_runtime_debug_environment() {
 
 policy_explain_print_summary() {
   local workdir_status config_status keychain_status exec_env_status env_pass_names_status profile_env_defaults_status
-  local git_worktree_common_dir_status git_worktree_paths_status
+  local git_worktree_common_dir_status git_worktree_paths_status trusted_workdirs_status trust_source_display
   local idx profile reason
   local host_command_matches execution_command_matches execution_path shell_wrapper_note runtime_debug_env_available=0
 
@@ -6292,6 +6417,27 @@ policy_explain_print_summary() {
     execution_command_matches="$(policy_explain_path_matches "${policy_req_invoked_command_path}" "$execution_path")"
   fi
 
+  if [[ "${#policy_req_trusted_workdirs[@]}" -gt 0 ]]; then
+    trusted_workdirs_status="$(safehouse_join_by_space "${policy_req_trusted_workdirs[@]}")"
+  else
+    trusted_workdirs_status="$(safehouse_join_by_space)"
+  fi
+
+  case "${policy_req_trust_workdir_config_source:-default}" in
+    --always-trust-workdir-config)
+      trust_source_display="--always-trust-workdir-config (persisted to ${policy_req_trusted_workdirs_path})"
+      ;;
+    --trust-workdir-config)
+      trust_source_display="--trust-workdir-config (this session only)"
+      ;;
+    trusted-workdirs)
+      trust_source_display="${policy_req_trusted_workdirs_path}"
+      ;;
+    *)
+      trust_source_display="${policy_req_trust_workdir_config_source:-default}"
+      ;;
+  esac
+
   shell_wrapper_note=""
   if [[ -n "${policy_req_invoked_command_path:-}" && "${policy_req_invoked_command_path}" != */* ]]; then
     shell_wrapper_note="interactive-shell aliases/functions are not introspected; run \`type -a ${policy_req_invoked_command_path}\` in your shell if wrapper resolution may matter"
@@ -6300,7 +6446,7 @@ policy_explain_print_summary() {
   {
     echo "safehouse explain:"
     echo "  effective workdir: ${workdir_status} (source: ${policy_req_effective_workdir_source:-unknown})"
-    echo "  workdir config trust: $([[ "$policy_req_trust_workdir_config" -eq 1 ]] && echo "enabled" || echo "disabled") (source: ${policy_req_trust_workdir_config_source})"
+    echo "  workdir config trust: $([[ "$policy_req_trust_workdir_config" -eq 1 ]] && echo "enabled" || echo "disabled") (source: ${trust_source_display})"
     echo "  workdir config: ${config_status}"
     echo "  git worktree common dir grant: ${git_worktree_common_dir_status}"
     echo "  git linked worktree read grants: ${git_worktree_paths_status}"
@@ -7655,7 +7801,13 @@ Policy scope options:
 
   --trust-workdir-config
   --trust-workdir-config=BOOL
-      Trust and load <workdir>/.safehouse (default: disabled)
+      Trust and load <workdir>/.safehouse this session (default: disabled)
+
+  --always-trust-workdir-config
+  --always-trust-workdir-config=BOOL
+      Trust and load <workdir>/.safehouse this and future sessions (default:
+      disabled). Remember <workdir> in ~/.config/safehouse/trusted-workdirs.
+      Conflicts with --trust-workdir-config=false/0/no/off.
 
   --allow-workdir-config-writes
       Skip the terminal deny-write rule for the workdir config file.
@@ -7725,6 +7877,11 @@ Config file:
       Supports keys:
         add-dirs-ro=PATHS
         add-dirs=PATHS
+
+  ~/.config/safehouse/trusted-workdirs (optional, always read)
+      One trusted directory path per line; blank lines and # comments allowed
+      Written by --always-trust-workdir-config. To remove entries edit directly
+      or use --always-trust-workdir-config=false.
 USAGE
 }
 
@@ -7750,6 +7907,8 @@ cli_policy_workdir_value=""
 cli_policy_trust_workdir_config_set=0
 cli_policy_trust_workdir_config_value=0
 cli_policy_allow_workdir_config_writes=0
+cli_policy_always_trust_workdir_config=0
+cli_policy_always_trust_workdir_config_set=0
 cli_policy_append_profiles=()
 cli_policy_allow_profile_writes=0
 cli_policy_output_path=""
@@ -7779,6 +7938,8 @@ cli_parse_reset() {
   cli_policy_trust_workdir_config_set=0
   cli_policy_trust_workdir_config_value=0
   cli_policy_allow_workdir_config_writes=0
+  cli_policy_always_trust_workdir_config=0
+  cli_policy_always_trust_workdir_config_set=0
   cli_policy_append_profiles=()
   cli_policy_allow_profile_writes=0
   cli_policy_output_path=""
@@ -7945,6 +8106,14 @@ cli_finalize_post_parse_state() {
   cli_finalize_runtime_env_inputs || return 1
   cli_finalize_wrapped_command_inputs || return 1
 
+  if [[ "$cli_policy_always_trust_workdir_config" -eq 1 && \
+        "$cli_policy_trust_workdir_config_set" -eq 1 && \
+        "$cli_policy_trust_workdir_config_value" -eq 0 ]]; then
+    safehouse_fail \
+      "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+    return 1
+  fi
+
   if [[ "${#cli_command_exec_args[@]}" -gt 0 ]]; then
     cli_has_command=1
   else
@@ -8053,6 +8222,29 @@ cli_parse_policy_flag_option() {
       ;;
     --allow-workdir-config-writes)
       cli_policy_allow_workdir_config_writes=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --always-trust-workdir-config)
+      cli_policy_always_trust_workdir_config=1
+      cli_policy_always_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --always-trust-workdir-config=*)
+      local always_trust_value
+      if policy_value_is_truthy "${current_arg#*=}"; then
+        always_trust_value=1
+      elif policy_value_is_falsey "${current_arg#*=}"; then
+        always_trust_value=0
+      else
+        safehouse_fail \
+          "Invalid value for --always-trust-workdir-config: ${current_arg#*=}" \
+          "Supported values: 1/0, true/false, yes/no, on/off"
+        return 1
+      fi
+      cli_policy_always_trust_workdir_config=$always_trust_value
+      cli_policy_always_trust_workdir_config_set=1
       cli_parse_consumed_args=1
       return 0
       ;;

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -8,6 +8,7 @@
 | `--add-dirs-ro=PATHS` | Colon-separated file/directory paths to grant read-only |
 | `--workdir=DIR` | Main directory to grant read/write (`--workdir=` disables automatic workdir grants) |
 | `--trust-workdir-config` | Trust and load `<workdir>/.safehouse` (`--trust-workdir-config=BOOL` also supported) |
+| `--always-trust-workdir-config` | Persist workdir to `~/.config/safehouse/trusted-workdirs` and trust it for this session (`--always-trust-workdir-config=BOOL` also supported) |
 | `--append-profile=PATH` | Append sandbox profile file after generated rules (repeatable) |
 | `--enable=FEATURES` | Enable optional features (see list below) |
 | `--env` | Pass the full inherited host env to the wrapped command, including secrets (incompatible with `--env-pass`) |
@@ -115,6 +116,24 @@ Supported keys:
 By default this file is ignored. It is loaded only with `--trust-workdir-config` (or `SAFEHOUSE_TRUST_WORKDIR_CONFIG`).
 Because the default workdir is the invocation directory, Safehouse does not auto-discover `.safehouse` files from enclosing Git repo roots when you launch from a nested subdirectory.
 Trusted config parsing fails fast on malformed lines and unknown keys.
+
+## Trusted Workdirs File
+
+Path: `~/.config/safehouse/trusted-workdirs`
+
+Format: one absolute directory path per line; blank lines and `#` comments are ignored.
+
+This file is written by `--always-trust-workdir-config`. To remove an entry, either run `safehouse --always-trust-workdir-config=false` from the directory or edit the file directly.
+
+When the current workdir matches an entry in this file, `.safehouse` is automatically trusted without any flag on every invocation.
+
+Trust precedence order (highest to lowest):
+
+1. `--always-trust-workdir-config=true` (writes to file, trusts this session)
+2. `--trust-workdir-config` (trusts this session only)
+3. `SAFEHOUSE_TRUST_WORKDIR_CONFIG` env var
+4. `~/.config/safehouse/trusted-workdirs` file match
+5. Default (not trusted)
 
 ## `--env=FILE` Format
 

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -7,7 +7,8 @@
 | `--add-dirs=PATHS` | Colon-separated file/directory paths to grant read/write |
 | `--add-dirs-ro=PATHS` | Colon-separated file/directory paths to grant read-only |
 | `--workdir=DIR` | Main directory to grant read/write (`--workdir=` disables automatic workdir grants) |
-| `--trust-workdir-config` | Trust and load `<workdir>/.safehouse` (`--trust-workdir-config=BOOL` also supported) |
+| `--trust-workdir-config` | Trust and load `<workdir>/.safehouse` in this session (`--trust-workdir-config=BOOL` also supported) |
+| `--always-trust-workdir-config` | Trust and load `<workdir>/.safehouse` in this and future sessions (`--always-trust-workdir-config=BOOL` also supported) |
 | `--allow-workdir-config-writes` | Skip the terminal deny-write rule for `<workdir>/.safehouse` (default: deny) |
 | `--append-profile=PATH` | Append sandbox profile file after generated rules (repeatable) |
 | `--allow-profile-writes` | Skip automatic deny-write rules for `--append-profile` files (default: deny) |
@@ -125,6 +126,24 @@ Because the default workdir is the invocation directory, Safehouse does not auto
 Trusted config parsing fails fast on malformed lines and unknown keys.
 
 Workdir config `append-profile=` files are applied before CLI `--append-profile` files, so CLI flags always take final precedence.
+
+## Trusted Workdirs File
+
+Path: `~/.config/safehouse/trusted-workdirs`
+
+Format: one absolute directory path per line; blank lines and `#` comments are ignored.
+
+This file is written by `--always-trust-workdir-config`. To remove an entry, either run `safehouse --always-trust-workdir-config=false` from the directory or edit the file directly.
+
+When the current workdir matches an entry in this file, `.safehouse` is automatically trusted without any flag on every invocation.
+
+Trust precedence order (highest to lowest):
+
+1. `--always-trust-workdir-config=true` (writes to file, trusts this session)
+2. `--trust-workdir-config` (trusts this session only)
+3. `SAFEHOUSE_TRUST_WORKDIR_CONFIG` env var
+4. `~/.config/safehouse/trusted-workdirs` file match
+5. Default (not trusted)
 
 ## `--env=FILE` Format
 

--- a/tests/policy/workdir/home-config.bats
+++ b/tests/policy/workdir/home-config.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# bats file_tags=suite:policy
+
+load ../../test_helper.bash
+
+@test "[POLICY-ONLY] trusted-workdirs file causes workdir config to be auto-trusted" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "home-config-ro")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile)"
+  sft_assert_contains "$profile" "$readonly_dir"
+}
+
+@test "[POLICY-ONLY] trusted-workdirs file with non-matching path does NOT auto-trust" {
+  local trusted_workdirs_file other_dir readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  other_dir="$(sft_external_dir "home-config-other")" || return 1
+  readonly_dir="$(sft_external_dir "home-config-ro-no-trust")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$other_dir" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile)"
+  sft_assert_not_contains "$profile" "$readonly_dir"
+}
+
+@test "[POLICY-ONLY] CLI --trust-workdir-config=0 overrides trusted-workdirs file auto-trust" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "home-config-ro-override")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile --trust-workdir-config=0)"
+  sft_assert_not_contains "$profile" "$readonly_dir"
+}
+
+@test "[POLICY-ONLY] trusted-workdirs file supports blank lines and # comments" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "home-config-ro-comments")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '# This is a comment\n\n%s\n\n# Another comment\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile)"
+  sft_assert_contains "$profile" "$readonly_dir"
+}
+
+@test "[POLICY-ONLY] trusted-workdirs file explain output shows loaded entries" {
+  local trusted_workdirs_file explain_log
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  explain_log="$(sft_workspace_path "explain-trusted.log")"
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+
+  safehouse_ok --explain --stdout >/dev/null 2>"$explain_log"
+
+  sft_assert_file_contains "$explain_log" "$trusted_workdirs_file"
+}

--- a/tests/policy/workdir/home-config.bats
+++ b/tests/policy/workdir/home-config.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# bats file_tags=suite:policy
+
+load ../../test_helper.bash
+
+@test "[POLICY-ONLY] trusted-workdirs file causes workdir config to be auto-trusted" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "home-config-ro")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile)"
+  sft_assert_contains "$profile" "$readonly_dir"
+}
+
+@test "[POLICY-ONLY] trusted-workdirs file with non-matching path does NOT auto-trust" {
+  local trusted_workdirs_file other_dir readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  other_dir="$(sft_external_dir "home-config-other")" || return 1
+  readonly_dir="$(sft_external_dir "home-config-ro-no-trust")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$other_dir" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile)"
+  sft_assert_not_contains "$profile" "$readonly_dir"
+}
+
+@test "[POLICY-ONLY] CLI --trust-workdir-config=0 overrides trusted-workdirs file auto-trust" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "home-config-ro-override")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile --trust-workdir-config=0)"
+  sft_assert_not_contains "$profile" "$readonly_dir"
+}
+
+@test "[POLICY-ONLY] trusted-workdirs file supports blank lines and # comments" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "home-config-ro-comments")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '# This is a comment\n\n%s\n\n# Another comment\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile)"
+  sft_assert_contains "$profile" "$readonly_dir"
+}
+
+@test "[POLICY-ONLY] trusted-workdirs entry under a path alias still auto-trusts" {
+  local trusted_workdirs_file alias_link readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "home-config-ro-alias")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  # A symlink to the workspace stands in for macOS aliases like /var -> /private/var:
+  # the file stores the aliased path while the effective workdir is normalized.
+  alias_link="$(sft_external_dir "home-config-alias-parent")/workdir-alias" || return 1
+  ln -s "$SAFEHOUSE_WORKSPACE" "$alias_link" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$alias_link" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile)"
+  sft_assert_contains "$profile" "$readonly_dir"
+}
+
+@test "[POLICY-ONLY] explain output names the trusted-workdirs file as the trust source" {
+  local trusted_workdirs_file explain_log
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  explain_log="$(sft_workspace_path "explain-trusted.log")"
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+
+  safehouse_ok --explain --stdout >/dev/null 2>"$explain_log"
+
+  sft_assert_file_contains "$explain_log" "workdir config trust: enabled (source: ${trusted_workdirs_file})"
+}
+
+@test "[EXECUTION] sandboxed process in a home subdir cannot write to the trusted-workdirs file" {
+  local workdir trusted_workdirs_file
+
+  workdir="${HOME}/subdir"
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+
+  mkdir -p "$workdir" || return 1
+  # Pre-create the parent directory so a denied write is the only reason the
+  # file cannot be created (rules out a spurious "no such directory" failure).
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+
+  # Default-deny: the workdir grant covers ~/subdir only, so a sandboxed process
+  # must not be able to self-escalate trust by appending to ~/.config/safehouse.
+  safehouse_denied_in_dir "$workdir" -- /bin/sh -c "printf '%s\n' '$workdir' >> '$trusted_workdirs_file'"
+  sft_assert_path_absent "$trusted_workdirs_file"
+}

--- a/tests/surface/cli/trust.bats
+++ b/tests/surface/cli/trust.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# bats file_tags=suite:surface
+
+load ../../test_helper.bash
+
+@test "--always-trust-workdir-config writes workdir to trusted-workdirs file" {
+  local trusted_workdirs_file
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+
+  safehouse_ok --always-trust-workdir-config --stdout >/dev/null
+
+  sft_assert_file_exists "$trusted_workdirs_file"
+  sft_assert_file_contains "$trusted_workdirs_file" "$SAFEHOUSE_WORKSPACE"
+}
+
+@test "--always-trust-workdir-config creates the file and parent dirs if they do not exist" {
+  local trusted_workdirs_file
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+
+  [ ! -e "$trusted_workdirs_file" ]
+
+  safehouse_ok --always-trust-workdir-config --stdout >/dev/null
+
+  sft_assert_file_exists "$trusted_workdirs_file"
+}
+
+@test "--always-trust-workdir-config is idempotent (running twice does not duplicate)" {
+  local trusted_workdirs_file count
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+
+  safehouse_ok --always-trust-workdir-config --stdout >/dev/null
+  safehouse_ok --always-trust-workdir-config --stdout >/dev/null
+
+  count="$(grep -cF "$SAFEHOUSE_WORKSPACE" "$trusted_workdirs_file" || true)"
+  [ "$count" -eq 1 ]
+}
+
+@test "--always-trust-workdir-config enables trust for the current invocation" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "always-trust-ro")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile --always-trust-workdir-config)"
+
+  sft_assert_contains "$profile" "$readonly_dir"
+  sft_assert_file_exists "$trusted_workdirs_file"
+  sft_assert_file_contains "$trusted_workdirs_file" "$SAFEHOUSE_WORKSPACE"
+}
+
+@test "--always-trust-workdir-config with --trust-workdir-config=false conflicts" {
+  safehouse_run --always-trust-workdir-config --trust-workdir-config=false --stdout
+  [ "$status" -ne 0 ]
+  sft_assert_contains "$output" "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+}
+
+@test "--trust-workdir-config=false with --always-trust-workdir-config conflicts regardless of order" {
+  safehouse_run --trust-workdir-config=false --always-trust-workdir-config --stdout
+  [ "$status" -ne 0 ]
+  sft_assert_contains "$output" "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+}
+
+@test "--always-trust-workdir-config conflicts with all falsy values of --trust-workdir-config" {
+  local falsy_val
+
+  for falsy_val in 0 no off; do
+    safehouse_run --always-trust-workdir-config "--trust-workdir-config=${falsy_val}" --stdout
+    [ "$status" -ne 0 ] || {
+      printf 'expected conflict error for --trust-workdir-config=%s\n' "$falsy_val" >&2
+      return 1
+    }
+    sft_assert_contains "$output" "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+  done
+}
+
+@test "--always-trust-workdir-config with --trust-workdir-config (bare) is allowed" {
+  safehouse_run --always-trust-workdir-config --trust-workdir-config --stdout
+  [ "$status" -eq 0 ]
+}
+
+@test "--always-trust-workdir-config with --trust-workdir-config=true is allowed" {
+  safehouse_run --always-trust-workdir-config --trust-workdir-config=true --stdout
+  [ "$status" -eq 0 ]
+}
+
+@test "[POLICY-ONLY] --always-trust-workdir-config=false removes workdir from trusted file and disables trust" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "always-trust-false-ro")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile --always-trust-workdir-config=false)"
+  sft_assert_not_contains "$profile" "$readonly_dir"
+
+  # Workdir should have been removed from the file
+  if [ -f "$trusted_workdirs_file" ]; then
+    local file_content
+    file_content="$(cat "$trusted_workdirs_file")"
+    sft_assert_not_contains "$file_content" "$SAFEHOUSE_WORKSPACE"
+  fi
+}
+
+@test "[POLICY-ONLY] --always-trust-workdir-config=false with --trust-workdir-config trusts this session but removes from file" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "always-trust-false-session-ro")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile --always-trust-workdir-config=false --trust-workdir-config)"
+  sft_assert_contains "$profile" "$readonly_dir"
+
+  # Workdir should have been removed from the file
+  if [ -f "$trusted_workdirs_file" ]; then
+    local file_content
+    file_content="$(cat "$trusted_workdirs_file")"
+    sft_assert_not_contains "$file_content" "$SAFEHOUSE_WORKSPACE"
+  fi
+}

--- a/tests/surface/cli/trust.bats
+++ b/tests/surface/cli/trust.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# bats file_tags=suite:surface
+
+load ../../test_helper.bash
+
+@test "--always-trust-workdir-config writes workdir to trusted-workdirs file" {
+  local trusted_workdirs_file
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+
+  safehouse_ok --always-trust-workdir-config --stdout >/dev/null
+
+  sft_assert_file_exists "$trusted_workdirs_file"
+  sft_assert_file_contains "$trusted_workdirs_file" "$SAFEHOUSE_WORKSPACE"
+}
+
+@test "--always-trust-workdir-config creates the file and parent dirs if they do not exist" {
+  local trusted_workdirs_file
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+
+  [ ! -e "$trusted_workdirs_file" ]
+
+  safehouse_ok --always-trust-workdir-config --stdout >/dev/null
+
+  sft_assert_file_exists "$trusted_workdirs_file"
+}
+
+@test "--always-trust-workdir-config is idempotent (running twice does not duplicate)" {
+  local trusted_workdirs_file count
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+
+  safehouse_ok --always-trust-workdir-config --stdout >/dev/null
+  safehouse_ok --always-trust-workdir-config --stdout >/dev/null
+
+  count="$(grep -cF "$SAFEHOUSE_WORKSPACE" "$trusted_workdirs_file" || true)"
+  [ "$count" -eq 1 ]
+}
+
+@test "--always-trust-workdir-config enables trust for the current invocation" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "always-trust-ro")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile --always-trust-workdir-config)"
+
+  sft_assert_contains "$profile" "$readonly_dir"
+  sft_assert_file_exists "$trusted_workdirs_file"
+  sft_assert_file_contains "$trusted_workdirs_file" "$SAFEHOUSE_WORKSPACE"
+}
+
+@test "--always-trust-workdir-config with --trust-workdir-config=false conflicts" {
+  safehouse_run --always-trust-workdir-config --trust-workdir-config=false --stdout
+  [ "$status" -ne 0 ]
+  sft_assert_contains "$output" "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+}
+
+@test "--trust-workdir-config=false with --always-trust-workdir-config conflicts regardless of order" {
+  safehouse_run --trust-workdir-config=false --always-trust-workdir-config --stdout
+  [ "$status" -ne 0 ]
+  sft_assert_contains "$output" "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+}
+
+@test "--always-trust-workdir-config conflicts with all falsy values of --trust-workdir-config" {
+  local falsy_val
+
+  for falsy_val in 0 no off; do
+    safehouse_run --always-trust-workdir-config "--trust-workdir-config=${falsy_val}" --stdout
+    [ "$status" -ne 0 ] || {
+      printf 'expected conflict error for --trust-workdir-config=%s\n' "$falsy_val" >&2
+      return 1
+    }
+    sft_assert_contains "$output" "--trust-workdir-config=false conflicts with --always-trust-workdir-config=true"
+  done
+}
+
+@test "--always-trust-workdir-config with --trust-workdir-config (bare) is allowed" {
+  safehouse_run --always-trust-workdir-config --trust-workdir-config --stdout
+  [ "$status" -eq 0 ]
+}
+
+@test "--always-trust-workdir-config with --trust-workdir-config=true is allowed" {
+  safehouse_run --always-trust-workdir-config --trust-workdir-config=true --stdout
+  [ "$status" -eq 0 ]
+}
+
+@test "unreadable trusted-workdirs file fails cleanly instead of silently degrading" {
+  local trusted_workdirs_file
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  chmod 000 "$trusted_workdirs_file" || return 1
+
+  safehouse_run --stdout
+  local run_status="$status"
+
+  chmod 600 "$trusted_workdirs_file" || return 1
+
+  [ "$run_status" -ne 0 ]
+  sft_assert_contains "$output" "Trusted workdirs file is not readable"
+}
+
+@test "non-regular trusted-workdirs path fails cleanly" {
+  local trusted_workdirs_file
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+
+  mkdir -p "$trusted_workdirs_file" || return 1
+
+  safehouse_run --stdout
+  [ "$status" -ne 0 ]
+  sft_assert_contains "$output" "Trusted workdirs path exists but is not a regular file"
+}
+
+@test "[POLICY-ONLY] --always-trust-workdir-config=false removes workdir from trusted file and disables trust" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "always-trust-false-ro")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile --always-trust-workdir-config=false)"
+  sft_assert_not_contains "$profile" "$readonly_dir"
+
+  # Workdir should have been removed from the file
+  if [ -f "$trusted_workdirs_file" ]; then
+    local file_content
+    file_content="$(cat "$trusted_workdirs_file")"
+    sft_assert_not_contains "$file_content" "$SAFEHOUSE_WORKSPACE"
+  fi
+}
+
+@test "[POLICY-ONLY] --always-trust-workdir-config=false with --trust-workdir-config trusts this session but removes from file" {
+  local trusted_workdirs_file readonly_dir config_file profile
+
+  trusted_workdirs_file="${HOME}/.config/safehouse/trusted-workdirs"
+  readonly_dir="$(sft_external_dir "always-trust-false-session-ro")" || return 1
+  config_file="$(sft_workspace_path ".safehouse")" || return 1
+
+  mkdir -p "$(dirname "$trusted_workdirs_file")" || return 1
+  printf '%s\n' "$SAFEHOUSE_WORKSPACE" > "$trusted_workdirs_file"
+  printf 'add-dirs-ro=%s\n' "$readonly_dir" > "$config_file"
+
+  profile="$(safehouse_profile --always-trust-workdir-config=false --trust-workdir-config)"
+  sft_assert_contains "$profile" "$readonly_dir"
+
+  # Workdir should have been removed from the file
+  if [ -f "$trusted_workdirs_file" ]; then
+    local file_content
+    file_content="$(cat "$trusted_workdirs_file")"
+    sft_assert_not_contains "$file_content" "$SAFEHOUSE_WORKSPACE"
+  fi
+}


### PR DESCRIPTION
Add saving persistent trust of workdir-config in ~/.config/safehouse/trusted-workdirs one workdir path per line. When the current workdir matches an entry, .safehouse is auto-trusted without any flag on every invocation.

Add --always-trust-workdir-config[=BOOL] flag. Setting this flag to true (default) writes the current workdir to the trusted file and also enables trust for this session. The false form removes the workdir from the file and won't trust the workdir config this session unless combined with --trust-workdir-config. If --always-trust-workdir-config=true is combined with --trust-workdir-config=false the safehouse will exit with an error.

Co-written with Claude.
This PR is part of a set of 4 PRs aiming to make it possible to safely run `safehouse` while passing minimal options.