### PR TITLE
profiles/10-system-runtime: allow file-ioctl on tty/pty so tcsetattr works

### DIFF
--- a/profiles/10-system-runtime.sb
+++ b/profiles/10-system-runtime.sb
@@ -84,6 +84,20 @@
 (allow mach-priv-task-port (target same-sandbox))                     ;; Required by some runtimes for same-sandbox process controls.
 (allow pseudo-tty)                                                    ;; Required for interactive terminal sessions and PTY allocation.
 
+;; TTY ioctls are a separate file-ioctl category in SBPL — `pseudo-tty`
+;; only covers /dev/ptmx allocation, not ioctls on the resulting tty fd.
+;; Without these, tcsetattr (TIOCSETAW = _IO('t',21)) and ptsname's
+;; TIOCPTYGNAME are denied, so any agent that switches the terminal to
+;; raw mode silently fails: the kernel keeps the line in cooked mode while
+;; the agent thinks it owns it, and every keypress + capability-query reply
+;; leaks into the agent's input buffer as literal escape sequences.
+(allow file-ioctl
+    (literal "/dev/tty")                                              ;; Controlling-terminal ioctls for foreground-process-group control.
+    (literal "/dev/ptmx")                                             ;; grantpt/unlockpt/ptsname ioctls on the PTY master.
+    (regex #"^/dev/ttys")                                             ;; tcsetattr/tcgetattr and window-size ioctls on macOS slave ttys.
+    (regex #"^/dev/pty")                                              ;; Legacy PTY naming used by some tools.
+)
+
 ; Broader permissions to get info of other processes for debugging
 ;(allow process-info-pidinfo)                                          ;; Process status polling for child supervision and cleanup.
 ;(allow process-info-setcontrol)                                       ;; Process control metadata updates used by CLI runtimes.


### PR DESCRIPTION
## Symptom

Under any sandbox-exec profile using the current base, agents that put the terminal into raw mode silently fail. With Claude Code on macOS (tested on Cmux and iTerm):

- Every keystroke leaks into the TUI input buffer as the literal escape sequence the terminal generates: `^[[99;5u` for Ctrl+C, `^[[27u` for Esc, `^[[I` / `^[[O` for focus events.
- Ctrl+C never delivers SIGINT.
- Terminal capability-query responses (`^[[?997;1n` for color theme, `^[[?62;22;52c` for DA1) leak into the input area at startup.

The exact same binary works fine outside the sandbox.

## Root cause

`(allow pseudo-tty)` only covers `posix_openpt`-style PTY allocation (opening `/dev/ptmx`). Ioctls on `/dev/tty`, `/dev/ttys*`, and `/dev/pty*` are a separate `file-ioctl` operation category in SBPL. The current `10-system-runtime.sb` grants `file-read*` and `file-write*` on those paths but no `file-ioctl`, so `tcsetattr` (`TIOCSETAW` = `_IO('t', 21)`) and `ptsname`'s `TIOCPTYGNAME` silently fail.

The agent flips its internal "we're in raw + kitty keyboard mode" state, but the kernel never actually changes the line discipline. The terminal stays cooked, the agent's parser is in raw-mode state, and everything mismatches.

## Diagnostic

Captured via `log stream --predicate 'sender == "Sandbox" AND eventMessage CONTAINS "claude"'`:

```
deny(1) file-ioctl path:/dev/ttys005 ioctl-command:(_IO "t" 21)   ;; TIOCSETAW
deny(1) file-ioctl path:/dev/ttys005 ioctl-command:(_IO "t" 83)   ;; TIOCPTYGNAME
```

## Fix

Scoped to the same tty/pty paths the file already lists for `file-read*`, so no widening of ioctl surface beyond what is already readable.

## Scope

Affects any agent that puts the terminal into raw mode, not Claude-specific. Verified the symptom and fix identically across iTerm, Ghostty, and cmux.

## Related

Discussion of the auth side (separate concern) on #88.
