### PR TITLE
node: allow SysV semaphores for LMDB cross-process locking

### DIFF
--- a/profiles/40-shared/ipc-sysv-sem.sb
+++ b/profiles/40-shared/ipc-sysv-sem.sb
@@ -1,0 +1,13 @@
+;; ---------------------------------------------------------------------------
+;; Category: Shared IPC (SysV semaphores)
+;; LMDB on macOS uses System V semaphores (`ftok`/`semget`/`semop`) for
+;; cross-process locking, because macOS lacks PTHREAD_PROCESS_SHARED robust
+;; mutexes and libmdb falls back to SysV IPC (`MDB_USE_SYSV_SEM`). Any
+;; sandboxed caller that opens an LMDB env hits this, regardless of
+;; language: `@parcel/cache` (Node, via pnpm/npm + Parcel builds), `heed`
+;; (Rust), `lmdb-py` (Python), `lmdb-go` (Go). Without this allow, the
+;; first `semget` returns EPERM and the env open fails.
+;; Source: 40-shared/ipc-sysv-sem.sb
+;; ---------------------------------------------------------------------------
+
+(allow ipc-sysv-sem)


### PR DESCRIPTION
*Written by Claude*

Fixes pnpm/npm installs that trigger a Parcel build inside the sandbox.

LMDB on macOS uses System V semaphores for cross-process locking because macOS lacks `PTHREAD_PROCESS_SHARED` robust mutexes, so libmdb falls back to SysV IPC. `@parcel/cache` opens an LMDB env at startup, so without `ipc-sysv-sem`, `lmdb.open()` returns EPERM and any package whose build hook runs Parcel fails to install.

Bisected the minimal allow on a direct `lmdb.open()` repro (see #100 for the full script):

| Allow | Result |
| --- | --- |
| `ipc-posix-sem` | fail |
| `ipc-posix-sem` + `ipc-posix-shm` | fail |
| `ipc-sysv-sem` | pass |

Closes #100.
