### PR TITLE
feat: add terminal deny rules to protect .safehouse from agent writes -- CONTINUED

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           brew install rustup
           printf '%s\n' "$(brew --prefix rustup)/bin" >> "${GITHUB_PATH}"
-          "$(brew --prefix rustup)/bin/rustup-init" -y --profile minimal --default-toolchain stable --no-modify-path
+          "$(brew --prefix rustup)/bin/rustup" toolchain install stable --profile minimal --no-self-update
           printf '%s\n' "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
 
       - name: Run test suite

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -74,8 +74,9 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"
         run: |
-          brew install rustup-init
-          rustup-init -y --profile minimal --default-toolchain stable --no-modify-path
+          brew install rustup
+          printf '%s\n' "$(brew --prefix rustup)/bin" >> "${GITHUB_PATH}"
+          "$(brew --prefix rustup)/bin/rustup-init" -y --profile minimal --default-toolchain stable --no-modify-path
           printf '%s\n' "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
 
       - name: Run test suite

--- a/bin/lib/cli/output.sh
+++ b/bin/lib/cli/output.sh
@@ -99,6 +99,14 @@ Policy scope options:
   --trust-workdir-config=BOOL
       Trust and load <workdir>/.safehouse (default: disabled)
 
+  --allow-workdir-config-writes
+      Skip the terminal deny-write rule for .safehouse config files.
+      By default, Safehouse always emits a deny file-write* rule for any
+      .safehouse file as the very last rule in the policy, ensuring agents
+      cannot modify workdir config regardless of path grants. Use this flag
+      only if you intentionally want the sandboxed process to be able to
+      write to .safehouse files.
+
   --append-profile PATH
   --append-profile=PATH
       Append an additional sandbox profile file after generated rules

--- a/bin/lib/cli/output.sh
+++ b/bin/lib/cli/output.sh
@@ -100,12 +100,12 @@ Policy scope options:
       Trust and load <workdir>/.safehouse (default: disabled)
 
   --allow-workdir-config-writes
-      Skip the terminal deny-write rule for .safehouse config files.
-      By default, Safehouse always emits a deny file-write* rule for any
-      .safehouse file as the very last rule in the policy, ensuring agents
-      cannot modify workdir config regardless of path grants. Use this flag
-      only if you intentionally want the sandboxed process to be able to
-      write to .safehouse files.
+      Skip the terminal deny-write rule for the workdir config file.
+      By default, Safehouse emits a deny file-write* rule for <workdir>/.safehouse
+      as the very last rule in the policy, ensuring agents cannot modify that
+      specific config file regardless of path grants. Use this flag only if you
+      intentionally want the sandboxed process to be able to write to
+      <workdir>/.safehouse.
 
   --append-profile PATH
   --append-profile=PATH

--- a/bin/lib/cli/parse.sh
+++ b/bin/lib/cli/parse.sh
@@ -19,6 +19,7 @@ cli_policy_workdir_set=0
 cli_policy_workdir_value=""
 cli_policy_trust_workdir_config_set=0
 cli_policy_trust_workdir_config_value=0
+cli_policy_allow_workdir_config_writes=0
 cli_policy_append_profiles=()
 cli_policy_output_path=""
 cli_policy_output_path_set=0
@@ -46,6 +47,7 @@ cli_parse_reset() {
   cli_policy_workdir_value=""
   cli_policy_trust_workdir_config_set=0
   cli_policy_trust_workdir_config_value=0
+  cli_policy_allow_workdir_config_writes=0
   cli_policy_append_profiles=()
   cli_policy_output_path=""
   cli_policy_output_path_set=0
@@ -309,6 +311,11 @@ cli_parse_policy_flag_option() {
         return 1
       fi
       cli_policy_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --allow-workdir-config-writes)
+      cli_policy_allow_workdir_config_writes=1
       cli_parse_consumed_args=1
       return 0
       ;;

--- a/bin/lib/policy/explain.sh
+++ b/bin/lib/policy/explain.sh
@@ -229,6 +229,7 @@ policy_explain_print_summary() {
         echo "  selected scoped profile: ${profile} (${reason})"
       done
     fi
+    echo "  allow workdir config writes: $([[ "$policy_req_allow_workdir_config_writes" -eq 1 ]] && echo "enabled" || echo "disabled (default)")"
     echo "  sandbox denial log hint: /usr/bin/log show --last 2m --style compact --predicate 'eventMessage CONTAINS \"Sandbox:\" AND eventMessage CONTAINS \"deny(\"'"
   } >&2
 }

--- a/bin/lib/policy/render.sh
+++ b/bin/lib/policy/render.sh
@@ -715,11 +715,26 @@ policy_render_emit_scoped_sections() {
   policy_render_append_scoped_module_dir "profiles/65-apps" || return 1
 }
 
+# Emit terminal deny rules that must survive all path grants.
+# These are always last so no (allow file-write* (subpath …)) from workdir,
+# extra-access-rules, wide-read, or appended profiles can override them.
+policy_render_emit_terminal_deny_rules() {
+  # Keep safehouse configs safe
+  if [[ "$policy_req_allow_workdir_config_writes" -eq 1 ]]; then
+    return 0
+  fi
+  policy_render_write_line ";; #safehouse-test-id:terminal-deny-safehouse# Terminal deny rules are emitted last so they override any earlier path grants."
+  policy_render_write_line ";; Agents must never modify Safehouse config files regardless of workdir grants."
+  policy_render_write_line "(deny file-write* (regex #\"/\\.safehouse\$\"))"
+  policy_render_write_blank
+}
+
 policy_render_emit_dynamic_sections() {
   policy_render_emit_extra_access_rules || return 1
   policy_render_emit_wide_read_access
   policy_render_emit_workdir_access "$policy_req_effective_workdir" || return 1
   policy_render_append_cli_profiles || return 1
+  policy_render_emit_terminal_deny_rules || return 1
 }
 
 policy_render_emit_all_sections() {

--- a/bin/lib/policy/render.sh
+++ b/bin/lib/policy/render.sh
@@ -719,13 +719,17 @@ policy_render_emit_scoped_sections() {
 # These are always last so no (allow file-write* (subpath …)) from workdir,
 # extra-access-rules, wide-read, or appended profiles can override them.
 policy_render_emit_terminal_deny_rules() {
-  # Keep safehouse configs safe
   if [[ "$policy_req_allow_workdir_config_writes" -eq 1 ]]; then
     return 0
   fi
+  if [[ -z "$policy_req_workdir_config_path" ]]; then
+    return 0
+  fi
+  local escaped_config_path
+  escaped_config_path="$(safehouse_escape_for_sb "$policy_req_workdir_config_path")" || return 1
   policy_render_write_line ";; #safehouse-test-id:terminal-deny-safehouse# Terminal deny rules are emitted last so they override any earlier path grants."
-  policy_render_write_line ";; Agents must never modify Safehouse config files regardless of workdir grants."
-  policy_render_write_line "(deny file-write* (regex #\"/\\.safehouse\$\"))"
+  policy_render_write_line ";; Agents must never modify the workdir Safehouse config regardless of workdir grants."
+  policy_render_write_line "(deny file-write* (literal \"${escaped_config_path}\"))"
   policy_render_write_blank
 }
 

--- a/bin/lib/policy/request.sh
+++ b/bin/lib/policy/request.sh
@@ -29,6 +29,7 @@ policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
 policy_req_workdir_config_ignored_untrusted=0
+policy_req_allow_workdir_config_writes=0
 policy_req_invoked_command_path=""
 policy_req_invoked_command_basename=""
 policy_req_invoked_command_profile_path=""
@@ -166,6 +167,7 @@ policy_request_reset() {
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
   policy_req_workdir_config_ignored_untrusted=0
+  policy_req_allow_workdir_config_writes=0
   policy_req_invoked_command_path=""
   policy_req_invoked_command_basename=""
   policy_req_invoked_command_profile_path=""
@@ -425,6 +427,10 @@ policy_request_load_effective_workdir_config() {
   fi
 }
 
+policy_request_resolve_allow_workdir_config_writes() {
+  policy_req_allow_workdir_config_writes="$cli_policy_allow_workdir_config_writes"
+}
+
 policy_request_merge_add_dir_inputs() {
   local config_ro_name="$1"
   local env_ro_name="$2"
@@ -484,6 +490,7 @@ policy_request_build() {
   policy_request_resolve_git_linked_worktree_access || return 1
   policy_request_resolve_append_profile_paths || return 1
   policy_request_load_effective_workdir_config config_add_dirs_ro_inputs config_add_dirs_rw_inputs || return 1
+  policy_request_resolve_allow_workdir_config_writes
   policy_request_merge_add_dir_inputs \
     config_add_dirs_ro_inputs \
     env_add_dirs_ro_inputs \

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -4151,6 +4151,7 @@ policy_req_workdir_config_path=""
 policy_req_workdir_config_loaded=0
 policy_req_workdir_config_found=0
 policy_req_workdir_config_ignored_untrusted=0
+policy_req_allow_workdir_config_writes=0
 policy_req_invoked_command_path=""
 policy_req_invoked_command_basename=""
 policy_req_invoked_command_profile_path=""
@@ -4288,6 +4289,7 @@ policy_request_reset() {
   policy_req_workdir_config_loaded=0
   policy_req_workdir_config_found=0
   policy_req_workdir_config_ignored_untrusted=0
+  policy_req_allow_workdir_config_writes=0
   policy_req_invoked_command_path=""
   policy_req_invoked_command_basename=""
   policy_req_invoked_command_profile_path=""
@@ -4547,6 +4549,10 @@ policy_request_load_effective_workdir_config() {
   fi
 }
 
+policy_request_resolve_allow_workdir_config_writes() {
+  policy_req_allow_workdir_config_writes="$cli_policy_allow_workdir_config_writes"
+}
+
 policy_request_merge_add_dir_inputs() {
   local config_ro_name="$1"
   local env_ro_name="$2"
@@ -4606,6 +4612,7 @@ policy_request_build() {
   policy_request_resolve_git_linked_worktree_access || return 1
   policy_request_resolve_append_profile_paths || return 1
   policy_request_load_effective_workdir_config config_add_dirs_ro_inputs config_add_dirs_rw_inputs || return 1
+  policy_request_resolve_allow_workdir_config_writes
   policy_request_merge_add_dir_inputs \
     config_add_dirs_ro_inputs \
     env_add_dirs_ro_inputs \
@@ -5793,11 +5800,26 @@ policy_render_emit_scoped_sections() {
   policy_render_append_scoped_module_dir "profiles/65-apps" || return 1
 }
 
+# Emit terminal deny rules that must survive all path grants.
+# These are always last so no (allow file-write* (subpath …)) from workdir,
+# extra-access-rules, wide-read, or appended profiles can override them.
+policy_render_emit_terminal_deny_rules() {
+  # Keep safehouse configs safe
+  if [[ "$policy_req_allow_workdir_config_writes" -eq 1 ]]; then
+    return 0
+  fi
+  policy_render_write_line ";; #safehouse-test-id:terminal-deny-safehouse# Terminal deny rules are emitted last so they override any earlier path grants."
+  policy_render_write_line ";; Agents must never modify Safehouse config files regardless of workdir grants."
+  policy_render_write_line "(deny file-write* (regex #\"/\\.safehouse\$\"))"
+  policy_render_write_blank
+}
+
 policy_render_emit_dynamic_sections() {
   policy_render_emit_extra_access_rules || return 1
   policy_render_emit_wide_read_access
   policy_render_emit_workdir_access "$policy_req_effective_workdir" || return 1
   policy_render_append_cli_profiles || return 1
+  policy_render_emit_terminal_deny_rules || return 1
 }
 
 policy_render_emit_all_sections() {
@@ -6096,6 +6118,7 @@ policy_explain_print_summary() {
         echo "  selected scoped profile: ${profile} (${reason})"
       done
     fi
+    echo "  allow workdir config writes: $([[ "$policy_req_allow_workdir_config_writes" -eq 1 ]] && echo "enabled" || echo "disabled (default)")"
     echo "  sandbox denial log hint: /usr/bin/log show --last 2m --style compact --predicate 'eventMessage CONTAINS \"Sandbox:\" AND eventMessage CONTAINS \"deny(\"'"
   } >&2
 }
@@ -7376,6 +7399,14 @@ Policy scope options:
   --trust-workdir-config=BOOL
       Trust and load <workdir>/.safehouse (default: disabled)
 
+  --allow-workdir-config-writes
+      Skip the terminal deny-write rule for .safehouse config files.
+      By default, Safehouse always emits a deny file-write* rule for any
+      .safehouse file as the very last rule in the policy, ensuring agents
+      cannot modify workdir config regardless of path grants. Use this flag
+      only if you intentionally want the sandboxed process to be able to
+      write to .safehouse files.
+
   --append-profile PATH
   --append-profile=PATH
       Append an additional sandbox profile file after generated rules
@@ -7453,6 +7484,7 @@ cli_policy_workdir_set=0
 cli_policy_workdir_value=""
 cli_policy_trust_workdir_config_set=0
 cli_policy_trust_workdir_config_value=0
+cli_policy_allow_workdir_config_writes=0
 cli_policy_append_profiles=()
 cli_policy_output_path=""
 cli_policy_output_path_set=0
@@ -7480,6 +7512,7 @@ cli_parse_reset() {
   cli_policy_workdir_value=""
   cli_policy_trust_workdir_config_set=0
   cli_policy_trust_workdir_config_value=0
+  cli_policy_allow_workdir_config_writes=0
   cli_policy_append_profiles=()
   cli_policy_output_path=""
   cli_policy_output_path_set=0
@@ -7743,6 +7776,11 @@ cli_parse_policy_flag_option() {
         return 1
       fi
       cli_policy_trust_workdir_config_set=1
+      cli_parse_consumed_args=1
+      return 0
+      ;;
+    --allow-workdir-config-writes)
+      cli_policy_allow_workdir_config_writes=1
       cli_parse_consumed_args=1
       return 0
       ;;

--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -5804,13 +5804,17 @@ policy_render_emit_scoped_sections() {
 # These are always last so no (allow file-write* (subpath …)) from workdir,
 # extra-access-rules, wide-read, or appended profiles can override them.
 policy_render_emit_terminal_deny_rules() {
-  # Keep safehouse configs safe
   if [[ "$policy_req_allow_workdir_config_writes" -eq 1 ]]; then
     return 0
   fi
+  if [[ -z "$policy_req_workdir_config_path" ]]; then
+    return 0
+  fi
+  local escaped_config_path
+  escaped_config_path="$(safehouse_escape_for_sb "$policy_req_workdir_config_path")" || return 1
   policy_render_write_line ";; #safehouse-test-id:terminal-deny-safehouse# Terminal deny rules are emitted last so they override any earlier path grants."
-  policy_render_write_line ";; Agents must never modify Safehouse config files regardless of workdir grants."
-  policy_render_write_line "(deny file-write* (regex #\"/\\.safehouse\$\"))"
+  policy_render_write_line ";; Agents must never modify the workdir Safehouse config regardless of workdir grants."
+  policy_render_write_line "(deny file-write* (literal \"${escaped_config_path}\"))"
   policy_render_write_blank
 }
 
@@ -7400,12 +7404,12 @@ Policy scope options:
       Trust and load <workdir>/.safehouse (default: disabled)
 
   --allow-workdir-config-writes
-      Skip the terminal deny-write rule for .safehouse config files.
-      By default, Safehouse always emits a deny file-write* rule for any
-      .safehouse file as the very last rule in the policy, ensuring agents
-      cannot modify workdir config regardless of path grants. Use this flag
-      only if you intentionally want the sandboxed process to be able to
-      write to .safehouse files.
+      Skip the terminal deny-write rule for the workdir config file.
+      By default, Safehouse emits a deny file-write* rule for <workdir>/.safehouse
+      as the very last rule in the policy, ensuring agents cannot modify that
+      specific config file regardless of path grants. Use this flag only if you
+      intentionally want the sandboxed process to be able to write to
+      <workdir>/.safehouse.
 
   --append-profile PATH
   --append-profile=PATH

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -8,6 +8,7 @@
 | `--add-dirs-ro=PATHS` | Colon-separated file/directory paths to grant read-only |
 | `--workdir=DIR` | Main directory to grant read/write (`--workdir=` disables automatic workdir grants) |
 | `--trust-workdir-config` | Trust and load `<workdir>/.safehouse` (`--trust-workdir-config=BOOL` also supported) |
+| `--allow-workdir-config-writes` | Skip the terminal deny-write rule for `.safehouse` config files (default: deny) |
 | `--append-profile=PATH` | Append sandbox profile file after generated rules (repeatable) |
 | `--enable=FEATURES` | Enable optional features (see list below) |
 | `--env` | Pass the full inherited host env to the wrapped command, including secrets (incompatible with `--env-pass`) |

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -8,7 +8,7 @@
 | `--add-dirs-ro=PATHS` | Colon-separated file/directory paths to grant read-only |
 | `--workdir=DIR` | Main directory to grant read/write (`--workdir=` disables automatic workdir grants) |
 | `--trust-workdir-config` | Trust and load `<workdir>/.safehouse` (`--trust-workdir-config=BOOL` also supported) |
-| `--allow-workdir-config-writes` | Skip the terminal deny-write rule for `.safehouse` config files (default: deny) |
+| `--allow-workdir-config-writes` | Skip the terminal deny-write rule for `<workdir>/.safehouse` (default: deny) |
 | `--append-profile=PATH` | Append sandbox profile file after generated rules (repeatable) |
 | `--enable=FEATURES` | Enable optional features (see list below) |
 | `--env` | Pass the full inherited host env to the wrapped command, including secrets (incompatible with `--env-pass`) |

--- a/docs/docs/policy-architecture.md
+++ b/docs/docs/policy-architecture.md
@@ -17,6 +17,7 @@ Policy assembly order:
 | `65-apps/*.sb` | Per-app bundle selection (`Claude.app`, `Visual Studio Code.app`) |
 | Config/env/CLI grants | Trusted `.safehouse` config, env grants, CLI grants, auto-detected app bundle read grant, selected workdir, launch-time active-worktree common-dir grant, and launch-time sibling worktree read grants |
 | Appended profiles | User profile overlays via `--append-profile` (loaded last) |
+| Terminal deny rules | Unconditional deny rules emitted after all path grants and appended profiles |
 
 ## Ordering Rules Matter
 
@@ -78,5 +79,11 @@ It is not a blanket grant for `$HOME`.
 Safehouse also generates a `file-read-metadata` block for `/`, the path to `$HOME`, and `$HOME` itself. That metadata-only traversal lets runtimes `stat` or walk toward explicitly allowed home-scoped paths without granting recursive reads of the whole home directory.
 
 In practice, that means `stat "$HOME"` can succeed while `ls "$HOME"` and `cat ~/secret.txt` still fail unless a more specific rule grants them.
+
+## Terminal Deny Rules
+
+To prevent accidentally granting access to some critical files Safehouse unconditionally emits a final deny block as the very last section of every generated policy. Since this block is always last, it wins over any earlier write grant regardless of how the workdir, additional profiles, etc are configured.
+
+Currently this is used to protect the `.safehouse` configuration file from being modified from inside the sandbox. To opt out pass `--allow-workdir-config-writes`.
 
 See also: [Bin Architecture](/docs/bin-architecture)

--- a/docs/docs/policy-architecture.md
+++ b/docs/docs/policy-architecture.md
@@ -84,6 +84,6 @@ In practice, that means `stat "$HOME"` can succeed while `ls "$HOME"` and `cat ~
 
 To prevent accidentally granting access to some critical files Safehouse unconditionally emits a final deny block as the very last section of every generated policy. Since this block is always last, it wins over any earlier write grant regardless of how the workdir, additional profiles, etc are configured.
 
-Currently this is used to protect the `.safehouse` configuration file from being modified from inside the sandbox. To opt out pass `--allow-workdir-config-writes`.
+Currently this is used to protect the workdir config file (`<workdir>/.safehouse`) from being modified from inside the sandbox. To opt out pass `--allow-workdir-config-writes`.
 
 See also: [Bin Architecture](/docs/bin-architecture)

--- a/tests/policy/workdir/workdir-config.bats
+++ b/tests/policy/workdir/workdir-config.bats
@@ -72,3 +72,24 @@ load ../../test_helper.bash
   sft_assert_contains "$output" ".safehouse:1: allow-home"
   sft_assert_contains "$output" "Supported keys: add-dirs-ro, add-dirs"
 }
+
+@test "[POLICY-ONLY] generated policy contains terminal deny sentinel for .safehouse writes" {
+  local profile
+
+  profile="$(safehouse_profile)"
+  sft_assert_contains "$profile" "#safehouse-test-id:terminal-deny-safehouse#"
+}
+
+@test "[POLICY-ONLY] terminal deny rule appears after workdir grant" {
+  local profile
+
+  profile="$(safehouse_profile)"
+  sft_assert_order "$profile" "#safehouse-test-id:workdir-grant#" "#safehouse-test-id:terminal-deny-safehouse#"
+}
+
+@test "[POLICY-ONLY] --allow-workdir-config-writes suppresses the terminal deny rule" {
+  local profile
+
+  profile="$(safehouse_profile --allow-workdir-config-writes)"
+  sft_assert_not_contains "$profile" "terminal-deny-safehouse"
+}

--- a/tests/policy/workdir/workdir-config.bats
+++ b/tests/policy/workdir/workdir-config.bats
@@ -93,3 +93,29 @@ load ../../test_helper.bash
   profile="$(safehouse_profile --allow-workdir-config-writes)"
   sft_assert_not_contains "$profile" "terminal-deny-safehouse"
 }
+
+@test "[EXECUTION] terminal deny rule blocks writes to <workdir>/.safehouse" {
+  local config_path
+
+  config_path="$(sft_workspace_path ".safehouse")" || return 1
+
+  safehouse_denied -- /bin/sh -c "printf 'add-dirs=/tmp\n' > '$config_path'"
+}
+
+@test "[EXECUTION] terminal deny rule does not block writes to <workdir>/sub/.safehouse" {
+  local sub_dir sub_config_path
+
+  sub_dir="$(sft_workspace_path "sub")" || return 1
+  sub_config_path="${sub_dir}/.safehouse"
+  mkdir -p "$sub_dir" || return 1
+
+  safehouse_ok -- /bin/sh -c "printf 'add-dirs=/tmp\n' > '$sub_config_path'"
+}
+
+@test "[EXECUTION] --allow-workdir-config-writes permits writes to <workdir>/.safehouse" {
+  local config_path
+
+  config_path="$(sft_workspace_path ".safehouse")" || return 1
+
+  safehouse_ok --allow-workdir-config-writes -- /bin/sh -c "printf 'add-dirs=/tmp\n' > '$config_path'"
+}


### PR DESCRIPTION
Extends existing PR https://github.com/eugene1g/agent-safehouse/pull/77 to integrate feedback from @eugene1g .

Only the commit by me (@davidfstr) on this branch is new. The commit from tomc-goodrx is the same as the one from the earlier PR.