### PR TITLE
feat: allow read Docker Desktop app for docker profile

### DIFF
--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -1570,6 +1570,22 @@ __SAFEHOUSE_EMBEDDED_profiles_55_integrations_optional_cloud_storage_sb__
     (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.rd/docker\\.sock$")))
 )
 
+;; Docker Desktop — CLI binary and shared resources.
+;; The standard Homebrew/core dump path `/usr/local/bin/docker` on Intel Macs
+;; and `/opt/homebrew/bin/docker` on Apple Silicon are symlinks into the
+;; Docker.app bundle; the symlink itself may be readable but the target binary
+;; is not, so we grant file-read* for the entire bundle tree.
+(allow file-read*
+    (literal "/Applications")
+    (subpath "/Applications/Docker.app")                                 ;; Docker Desktop CLI binary and bundled tools.
+
+    ;; Compatibility alias on Intel Macs where /Applications lives under
+    ;; /System/Volumes/Data.
+    (literal "/System/Volumes/Data")
+    (literal "/System/Volumes/Data/Applications")
+    (subpath "/System/Volumes/Data/Applications/Docker.app")
+)
+
 ;; OrbStack (Docker Desktop alternative) — shell completions and CLI helpers.
 (allow file-read*
     (subpath "/Applications/OrbStack.app/Contents/Resources/completions")  ;; Zsh/bash completions sourced during shell init.

--- a/profiles/55-integrations-optional/docker.sb
+++ b/profiles/55-integrations-optional/docker.sb
@@ -26,6 +26,22 @@
     (remote unix-socket (path-regex (string-append "^" HOME_DIR "/\\.rd/docker\\.sock$")))
 )
 
+;; Docker Desktop — CLI binary and shared resources.
+;; The standard Homebrew/core dump path `/usr/local/bin/docker` on Intel Macs
+;; and `/opt/homebrew/bin/docker` on Apple Silicon are symlinks into the
+;; Docker.app bundle; the symlink itself may be readable but the target binary
+;; is not, so we grant file-read* for the entire bundle tree.
+(allow file-read*
+    (literal "/Applications")
+    (subpath "/Applications/Docker.app")                                 ;; Docker Desktop CLI binary and bundled tools.
+
+    ;; Compatibility alias on Intel Macs where /Applications lives under
+    ;; /System/Volumes/Data.
+    (literal "/System/Volumes/Data")
+    (literal "/System/Volumes/Data/Applications")
+    (subpath "/System/Volumes/Data/Applications/Docker.app")
+)
+
 ;; OrbStack (Docker Desktop alternative) — shell completions and CLI helpers.
 (allow file-read*
     (subpath "/Applications/OrbStack.app/Contents/Resources/completions")  ;; Zsh/bash completions sourced during shell init.

--- a/tests/policy/integrations/docker.bats
+++ b/tests/policy/integrations/docker.bats
@@ -30,6 +30,14 @@ load ../../test_helper.bash
   sft_assert_order "$profile" "$(sft_source_marker "50-integrations-core/container-runtime-default-deny.sb")" "$(sft_source_marker "55-integrations-optional/docker.sb")"
 }
 
+@test "[POLICY-ONLY] enable=docker grants read access to Docker.app bundle" { # https://github.com/eugene1g/agent-safehouse/issues/117
+  local profile
+  profile="$(safehouse_profile --enable=docker)"
+
+  sft_assert_contains "$profile" "(subpath \"/Applications/Docker.app\")"
+  sft_assert_contains "$profile" "/Applications/Docker.app"
+}
+
 @test "[EXECUTION] docker cli can reach the configured daemon only when enable=docker is set" { # https://github.com/eugene1g/agent-safehouse/issues/19
   local docker_bin
 


### PR DESCRIPTION
hombrew-installed Docker Desktop's binary is just a symlink to the proper app bundle
addresses #117