### PR TITLE
feat: allow r/w on fnm multishells to allow agents to, e.g., `fnm use`

### DIFF
--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -589,6 +589,9 @@ __SAFEHOUSE_EMBEDDED_profiles_30_toolchains_java_sb__
     (home-subpath "/.local/share/fnm")  ;; Linux/XDG default fnm install root for managed Node runtimes and package manager payloads.
     (home-subpath "/Library/Application Support/fnm")  ;; macOS default fnm install root when XDG_DATA_HOME is unset.
 
+    ;; fnm per-shell shim directory (required for fnm execution via multishell symlinks).
+    (home-subpath "/.local/state/fnm_multishells")
+
     ;; npm
     (home-subpath "/.npm")
     (home-subpath "/.config/npm")
@@ -9659,6 +9662,9 @@ policy_dist_append_preassembled_fixed_after_home() {
     (home-subpath "/.fnm")
     (home-subpath "/.local/share/fnm")  ;; Linux/XDG default fnm install root for managed Node runtimes and package manager payloads.
     (home-subpath "/Library/Application Support/fnm")  ;; macOS default fnm install root when XDG_DATA_HOME is unset.
+
+    ;; fnm per-shell shim directory (required for fnm execution via multishell symlinks).
+    (home-subpath "/.local/state/fnm_multishells")
 
     ;; npm
     (home-subpath "/.npm")

--- a/profiles/30-toolchains/node.sb
+++ b/profiles/30-toolchains/node.sb
@@ -15,6 +15,9 @@
     (home-subpath "/.local/share/fnm")  ;; Linux/XDG default fnm install root for managed Node runtimes and package manager payloads.
     (home-subpath "/Library/Application Support/fnm")  ;; macOS default fnm install root when XDG_DATA_HOME is unset.
 
+    ;; fnm per-shell shim directory (required for fnm execution via multishell symlinks).
+    (home-subpath "/.local/state/fnm_multishells")
+
     ;; npm
     (home-subpath "/.npm")
     (home-subpath "/.config/npm")

--- a/tests/policy/runtime/toolchains.bats
+++ b/tests/policy/runtime/toolchains.bats
@@ -41,6 +41,13 @@ load ../../test_helper.bash
   sft_assert_contains "$profile" "(home-subpath \"/Library/Application Support/fnm\")"
 }
 
+@test "[POLICY-ONLY] node toolchain grants file-read* file-write* to fnm_multishells" { # issue #111
+  local profile
+  profile="$(safehouse_profile)"
+
+  sft_assert_contains "$profile" "(home-subpath \"/.local/state/fnm_multishells\")"
+}
+
 @test "[POLICY-ONLY] apple toolchain core includes the curated CLT aliases used by common builds" { # https://github.com/eugene1g/agent-safehouse/issues/57
   local profile binary
   local -a binaries=(c++ cc g++ ranlib c++filt gcov lorder nm objdump otool size)


### PR DESCRIPTION
closes #111