### PR TITLE
fix: allow Codex to read bundled node_repl (TG-4205)

### DIFF
--- a/dist/safehouse.sh
+++ b/dist/safehouse.sh
@@ -2496,6 +2496,14 @@ __SAFEHOUSE_EMBEDDED_profiles_60_agents_cline_sb__
     (home-subpath "/.cache/codex")
 )
 
+;; ChatGPT-installed Codex launches its bundled node_repl MCP server with the
+;; adjacent Node runtime/modules and passes this bundled CLI path via
+;; CODEX_CLI_PATH. Keep this narrower than the full ChatGPT app bundle.
+(allow file-read*
+    (subpath "/Applications/ChatGPT.app/Contents/Resources/cua_node")
+    (literal "/Applications/ChatGPT.app/Contents/Resources/codex")
+)
+
 (allow file-read*
     (home-literal "/Library/Preferences/com.openai.codex.plist")  ;; Codex user-level preferences plist.
     (literal "/Library/Preferences/com.openai.codex.plist")       ;; Codex system preferences plist (managed setups).

--- a/profiles/60-agents/codex.sb
+++ b/profiles/60-agents/codex.sb
@@ -16,6 +16,14 @@
     (home-subpath "/.cache/codex")
 )
 
+;; ChatGPT-installed Codex launches its bundled node_repl MCP server with the
+;; adjacent Node runtime/modules and passes this bundled CLI path via
+;; CODEX_CLI_PATH. Keep this narrower than the full ChatGPT app bundle.
+(allow file-read*
+    (subpath "/Applications/ChatGPT.app/Contents/Resources/cua_node")
+    (literal "/Applications/ChatGPT.app/Contents/Resources/codex")
+)
+
 (allow file-read*
     (home-literal "/Library/Preferences/com.openai.codex.plist")  ;; Codex user-level preferences plist.
     (literal "/Library/Preferences/com.openai.codex.plist")       ;; Codex system preferences plist (managed setups).

--- a/tests/policy/agents/codex.bats
+++ b/tests/policy/agents/codex.bats
@@ -3,8 +3,8 @@
 
 load ../../test_helper.bash
 
-@test "[POLICY-ONLY] codex command grants only the ChatGPT-bundled node_repl resources read access" {
-  local profile codex_section chatgpt_path_count
+@test "[POLICY-ONLY] codex grants narrow read access to ChatGPT-bundled node_repl resources" {
+  local profile codex_section
 
   profile="$(safehouse_profile -- codex)"
   codex_section="$(sft_profile_source_section "$profile" "60-agents/codex.sb")"
@@ -15,11 +15,4 @@ load ../../test_helper.bash
 )'
   sft_assert_not_contains "$codex_section" '(subpath "/Applications/ChatGPT.app")'
   sft_assert_not_contains "$codex_section" '(subpath "/Applications")'
-  sft_assert_not_contains "$codex_section" '(allow file-read* file-write*
-    (subpath "/Applications/ChatGPT.app/Contents/Resources/cua_node")'
-  sft_assert_not_contains "$codex_section" '(allow file-write*
-    (subpath "/Applications/ChatGPT.app/Contents/Resources/cua_node")'
-
-  chatgpt_path_count="$(printf '%s\n' "$codex_section" | rg -c '/Applications/ChatGPT\.app')"
-  [ "$chatgpt_path_count" -eq 2 ]
 }

--- a/tests/policy/agents/codex.bats
+++ b/tests/policy/agents/codex.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# bats file_tags=suite:policy
+
+load ../../test_helper.bash
+
+@test "[POLICY-ONLY] codex command grants only the ChatGPT-bundled node_repl resources read access" {
+  local profile codex_section chatgpt_path_count
+
+  profile="$(safehouse_profile -- codex)"
+  codex_section="$(sft_profile_source_section "$profile" "60-agents/codex.sb")"
+
+  sft_assert_contains "$codex_section" '(allow file-read*
+    (subpath "/Applications/ChatGPT.app/Contents/Resources/cua_node")
+    (literal "/Applications/ChatGPT.app/Contents/Resources/codex")
+)'
+  sft_assert_not_contains "$codex_section" '(subpath "/Applications/ChatGPT.app")'
+  sft_assert_not_contains "$codex_section" '(subpath "/Applications")'
+  sft_assert_not_contains "$codex_section" '(allow file-read* file-write*
+    (subpath "/Applications/ChatGPT.app/Contents/Resources/cua_node")'
+  sft_assert_not_contains "$codex_section" '(allow file-write*
+    (subpath "/Applications/ChatGPT.app/Contents/Resources/cua_node")'
+
+  chatgpt_path_count="$(printf '%s\n' "$codex_section" | rg -c '/Applications/ChatGPT\.app')"
+  [ "$chatgpt_path_count" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

Grant the Codex CLI profile read-only access to the ChatGPT-bundled `node_repl` subtree and the single bundled Codex CLI file.

`node_repl` loads its adjacent runtime and modules, so the grant must cover the `cua_node` subtree:

```text
cua_node/                  # simplified
├── bin/
│   └── node_repl
├── bundled Node runtime files
└── bundled JavaScript modules
```

The profile uses `subpath` for `cua_node` and `literal` for `Resources/codex`. It does not grant write access or recursive access to the rest of `ChatGPT.app` or `/Applications`.

The focused rendered-policy regression checks the exact read rule in `profiles/60-agents/codex.sb` and rejects broader recursive grants. The generated `dist/safehouse.sh` contains the same policy.

## Error avoided

This avoids the following error when using Codex with Safehouse:

```text
⚠ MCP client for `node_repl` failed to start: MCP startup failed: No such file or directory (os error 2)

⚠ MCP startup incomplete (failed: node_repl)
```

## Validation

- `HOME=/tmp /tmp/safehouse-bats-core-tg4205/bin/bats tests/policy/agents/codex.bats`
- `bash -n bin/safehouse.sh scripts/generate-dist.sh dist/safehouse.sh`
- Deterministic `./scripts/generate-dist.sh` regeneration and rendered dist policy assertions
- `git diff --check`
- Not run: `./tests/run.sh` and live `node_repl` E2E. This Codex session is already sandboxed, so nested `sandbox-exec` fails with `Operation not permitted`.

## Notes

Closes tg-4205

Agent session: `codex resume 019f8c22-97c7-7f32-a088-a5607f0ba946`

<sub>🤖 <code>cb-ship:created v1 core@3.23.0</code></sub>