### PR TITLE
chore(e2e): update model pins to current generation

### DIFF
--- a/.github/workflows/e2e-agent-tui-macos.yml
+++ b/.github/workflows/e2e-agent-tui-macos.yml
@@ -55,9 +55,9 @@ jobs:
           brew install bats-core parallel tmux node aider block-goose-cli
           npm install --global --no-fund --no-audit \
             @anthropic-ai/claude-code \
+            @earendil-works/pi-coding-agent \
             @google/gemini-cli \
             @kilocode/cli \
-            @mariozechner/pi-coding-agent \
             @openai/codex \
             @sourcegraph/amp \
             opencode-ai

--- a/tests/e2e/aider.bats
+++ b/tests/e2e/aider.bats
@@ -18,7 +18,7 @@ load agent_tui_harness.bash
   local trust_gate_pattern=""
   local permission_gate_pattern=""
   local restart_gate_pattern=""
-  local model="gpt-5-mini"
+  local model="gpt-5.6-luna"
 
   prepare_agent_state "${agent_home}" "${config_dir}" "${input_history_path}" "${chat_history_path}"
   login_agent "${config_dir}" "${auth_log_path}" "${model}"

--- a/tests/e2e/claude-code.bats
+++ b/tests/e2e/claude-code.bats
@@ -16,7 +16,7 @@ load agent_tui_harness.bash
   local trust_gate_pattern=""
   local permission_gate_pattern=""
   local restart_gate_pattern=""
-  local model="claude-haiku-4-5"
+  local model="claude-sonnet-5"
   local api_key="${ANTHROPIC_API_KEY}"
 
   prepare_agent_state "${agent_home}" "${config_dir}"

--- a/tests/e2e/cline.bats
+++ b/tests/e2e/cline.bats
@@ -16,7 +16,7 @@ load agent_tui_harness.bash
   local trust_gate_pattern=""
   local permission_gate_pattern=""
   local restart_gate_pattern=""
-  local model="gpt-5-mini"
+  local model="gpt-5.6-luna"
 
   prepare_agent_state "${agent_home}" "${config_dir}"
   login_agent "${config_dir}" "${auth_log_path}" "${model}"

--- a/tests/e2e/codex.bats
+++ b/tests/e2e/codex.bats
@@ -16,7 +16,7 @@ load agent_tui_harness.bash
   local trust_gate_pattern='Do you trust the contents of this directory'
   local permission_gate_pattern=""
   local restart_gate_pattern=""
-  local model="gpt-5-mini"
+  local model="gpt-5.6-luna"
 
   prepare_agent_state "${agent_home}" "${config_dir}" "${model}"
   login_agent "${config_dir}" "${auth_log_path}" "${model}"

--- a/tests/e2e/goose.bats
+++ b/tests/e2e/goose.bats
@@ -17,7 +17,7 @@ load agent_tui_harness.bash
   local permission_gate_pattern=""
   local telemetry_gate_pattern='Share anonymous usage data'
   local restart_gate_pattern=""
-  local model="gpt-5-mini"
+  local model="gpt-5.6-luna"
 
   prepare_agent_state "${agent_home}" "${config_dir}" "${model}"
   login_agent "${config_dir}" "${auth_log_path}" "${model}"

--- a/tests/e2e/kilo-code.bats
+++ b/tests/e2e/kilo-code.bats
@@ -16,7 +16,7 @@ load agent_tui_harness.bash
   local trust_gate_pattern=""
   local permission_gate_pattern=""
   local restart_gate_pattern='Performing one time database migration|Database migration complete'
-  local model="openai/gpt-5-mini"
+  local model="openai/gpt-5.6-luna"
 
   prepare_agent_state "${agent_home}" "${config_dir}"
   login_agent "${config_dir}" "${auth_log_path}" "${model}"

--- a/tests/e2e/opencode.bats
+++ b/tests/e2e/opencode.bats
@@ -12,7 +12,7 @@ load agent_tui_harness.bash
   local agent_home="${AGENT_TUI_WORKDIR}/opencode-home"
   local config_dir="${AGENT_TUI_WORKDIR}/opencode-config"
   local auth_log_path="${AGENT_TUI_ROOT}/opencode-login.log"
-  local model="anthropic/claude-haiku-4-5"
+  local model="anthropic/claude-sonnet-5"
 
   prepare_agent_state "${agent_home}" "${config_dir}"
   login_agent "${config_dir}" "${auth_log_path}" "${model}"

--- a/tests/e2e/pi.bats
+++ b/tests/e2e/pi.bats
@@ -17,7 +17,7 @@ load agent_tui_harness.bash
   PI_CODING_AGENT_DIR="${agent_home}" \
   sft_tmux_start \
     safehouse --env-pass=ANTHROPIC_API_KEY,PI_CODING_AGENT_DIR -- \
-    pi --model anthropic/haiku:low
-  sft_tmux_wait_until_regex "claude-haiku"
+    pi --model anthropic/claude-sonnet-5:low
+  sft_tmux_wait_until_regex "claude-sonnet"
   sft_tmux_assert_roundtrip
 }


### PR DESCRIPTION
## Summary

Moves the tmux-driven agent TUI e2e tests onto current-generation models. Both providers were pinned to models from the previous generation.

| Suite | Before | After |
|---|---|---|
| codex, aider, goose, cline | `gpt-5-mini` | `gpt-5.6-luna` |
| kilo-code | `openai/gpt-5-mini` | `openai/gpt-5.6-luna` |
| claude-code | `claude-haiku-4-5` | `claude-sonnet-5` |
| opencode | `anthropic/claude-haiku-4-5` | `anthropic/claude-sonnet-5` |
| pi | `anthropic/haiku:low` | `anthropic/claude-sonnet-5:low` |

## Notes

- **pi now pins the full model ID** rather than the short `sonnet` alias. pi resolves bare aliases by glob against the provider's model list (`dist/core/model-resolver.js`), and `sonnet` matches `claude-sonnet-5`, `claude-sonnet-4-6`, and `claude-sonnet-4-5` — which one wins depends on pi's internal preference ordering rather than anything the test states. The TUI assertion regex moves from `claude-haiku` to `claude-sonnet` alongside it.
- **Effort settings carry over.** claude-code's `--effort low` and pi's `:low` suffix are now actually meaningful; Haiku 4.5 has no `effort` support at all.
- **Cost:** Sonnet 5 is \$2/\$10 per MTok vs Haiku 4.5's \$1/\$5, so the Anthropic-backed tests roughly double in cost per CI run for what is only a boot-and-roundtrip smoke check. Happy to drop back to Haiku if that tradeoff isn't wanted.

## Test plan

No `.sb` or policy-assembly files changed, so no `generate-dist.sh` run is required and the policy/surface suites are unaffected.

These tests were not run locally — they need a live `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` and tmux-driven agent TUIs. Verification is the `e2e-agent-tui-macos.yml` workflow, which is where the new model IDs get exercised for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)