### PR TITLE
chore(e2e): run cline and copilot in CI, unstall pi startup

### DIFF
--- a/.github/workflows/e2e-agent-tui-macos.yml
+++ b/.github/workflows/e2e-agent-tui-macos.yml
@@ -52,7 +52,9 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"
         run: |
-          brew install bats-core parallel tmux node aider block-goose-cli
+          # fd/ripgrep are for pi: it downloads its own copies at first launch when they
+          # are missing from PATH, which delays the TUI past the roundtrip timeout
+          brew install bats-core parallel tmux node aider block-goose-cli fd ripgrep
           npm install --global --no-fund --no-audit \
             @anthropic-ai/claude-code \
             @earendil-works/pi-coding-agent \

--- a/.github/workflows/e2e-agent-tui-macos.yml
+++ b/.github/workflows/e2e-agent-tui-macos.yml
@@ -56,10 +56,12 @@ jobs:
           npm install --global --no-fund --no-audit \
             @anthropic-ai/claude-code \
             @earendil-works/pi-coding-agent \
+            @github/copilot \
             @google/gemini-cli \
             @kilocode/cli \
             @openai/codex \
             @sourcegraph/amp \
+            cline \
             opencode-ai
 
       - name: Run agent TUI tests

--- a/tests/e2e/cline.bats
+++ b/tests/e2e/cline.bats
@@ -16,6 +16,9 @@ load agent_tui_harness.bash
   local trust_gate_pattern=""
   local permission_gate_pattern=""
   local restart_gate_pattern=""
+  # cline overlays a "Try ClinePass" subscription promo on the input line at startup;
+  # it closes on any key other than Enter (Enter opens the signup URL in a browser)
+  local promo_gate_pattern='Try ClinePass|any other key to close'
   local model="gpt-5.6-luna"
 
   prepare_agent_state "${agent_home}" "${config_dir}"
@@ -60,6 +63,7 @@ handle_startup_gates() {
     "${trust_gate_pattern:-}"
     "${permission_gate_pattern:-}"
     "${restart_gate_pattern:-}"
+    "${promo_gate_pattern:-}"
   )
 
   (( pass <= 5 )) || {
@@ -82,6 +86,14 @@ handle_startup_gates() {
       sft_agent_tui_write_screen_capture >&2 || true
       return 1
     }
+
+  # Dismiss the promo before checking input readiness: the overlay leaves part of the
+  # input line visible, so input_ready can match while the prompt is still covered.
+  if [[ -n "${promo_gate_pattern:-}" ]] && sft_tmux_matches_regex "${promo_gate_pattern}"; then
+    sft_tmux_send_keys Escape
+    handle_startup_gates "$((pass + 1))"
+    return $?
+  fi
 
   if sft_tmux_matches_regex "${input_ready_pattern}"; then
     return 0


### PR DESCRIPTION
## What

- Installs `cline` and `@github/copilot` in the e2e workflow, so their tests actually run
- Dismisses cline's "Try ClinePass" startup overlay
- Preinstalls `fd`/`ripgrep` so pi does not download them mid-startup

## Why

Asked to bump the agent clients CI uses to their current versions — but there are no version pins to bump. Every client is installed unpinned (`brew install ...` / `npm install --global ...`), so each run already resolves the latest release. I audited all of them against npm anyway, since the pi failure in #161 turned out to be a stale *package identity* rather than a stale pin:

| CLI | package | latest | last publish |
| --- | --- | --- | --- |
| claude | `@anthropic-ai/claude-code` | 2.1.233 | 2026-08-14 |
| pi | `@earendil-works/pi-coding-agent` | 0.84.2 | 2026-08-14 |
| gemini | `@google/gemini-cli` | 0.55.1 | 2026-08-16 |
| kilo | `@kilocode/cli` | 7.4.22 | 2026-08-13 |
| codex | `@openai/codex` | 0.147.0 | 2026-08-16 |
| amp | `@sourcegraph/amp` | 0.0.1786867375-g08199f | 2026-08-16 |
| opencode | `opencode-ai` | 1.18.18 | 2026-08-16 |

All actively published, none deprecated, none renamed. `@mariozechner/pi-coding-agent` was the only stale one and is already fixed on main.

The real gap was coverage. `cline.bats` and `copilot.bats` have always reported `# skip <agent> is not installed`, because the workflow's npm line is the only install path in the repo and neither CLI was on it — so two clients this repo ships profiles for were never verified end to end. Installing them surfaced two real problems:

**cline** boots, then draws a "Try ClinePass" subscription overlay across the input line, which no gate pattern handled. It closes on any key except Enter (Enter opens the signup URL in a browser), so Escape dismisses it. The promo check runs before the input-readiness check, because the overlay leaves part of the input line visible and `input_ready_pattern` can match while the prompt is still covered.

**pi** was failing on main again after the package switch, for a new reason: 0.84.2 downloads its own fd and ripgrep at first launch when they are missing from PATH (`fd not found. Downloading...`), and the prompt gets submitted while the TUI still reports `Startup is still in progress`, so the roundtrip times out. pi consults system PATH before downloading (`dist/utils/tools-manager.js` `getToolPath`), so brew-installing fd and ripgrep removes the download rather than masking it with a longer timeout.

## Result

All 16 e2e tests pass with no skips — the first run where every agent client is actually exercised:

```
ok 3 [E2E-TUI] cline boots and completes roundtrip in 17965ms
ok 5 [E2E-TUI] copilot boots to startup screen in 12557ms
ok 10 [E2E-TUI] pi boots and completes roundtrip in 15932ms
```

## Note

`@sourcegraph/amp` is installed but no e2e test uses it (there is a `profiles/60-agents/amp.sb`, but no `amp.bats`). Left as-is — either it wants a test or it wants dropping from the install list, and that is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)