### PR TITLE
feat(ci): Enforce that GitHub Action workflows are zizmor-clean

### DIFF
--- a/.github/workflows/deploy-docs-cloudflare.yml
+++ b/.github/workflows/deploy-docs-cloudflare.yml
@@ -21,14 +21,16 @@ concurrency:
 
 jobs:
   deploy:
+    name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6
         with:
           node-version: 24
           cache: pnpm
@@ -37,7 +39,7 @@ jobs:
       - run: pnpm run docs:build
 
       - name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-docs-cloudflare.yml
+++ b/.github/workflows/deploy-docs-cloudflare.yml
@@ -45,8 +45,13 @@ jobs:
 
       - name: Deploy
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3
+        # NOTE: ignore[secrets-outside-env]: This workflow can only run with
+        #       maintainer-reviewed code on the main branch. Maintainer review
+        #       is considered sufficient protection against the merge of code
+        #       that tries to exfiltrate secrets. See discussion in:
+        #       https://github.com/eugene1g/agent-safehouse/issues/137
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}  # zizmor: ignore[secrets-outside-env]
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}  # zizmor: ignore[secrets-outside-env]
           wranglerVersion: "4.65.0"
           command: deploy --env production --var GIT_SHA:${{ github.sha }}

--- a/.github/workflows/deploy-docs-cloudflare.yml
+++ b/.github/workflows/deploy-docs-cloudflare.yml
@@ -33,7 +33,13 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6
         with:
           node-version: 24
-          cache: pnpm
+
+          # NOTE: Unsafe to rely on possibly-poisoned cache within a workflow
+          #       that uses ${{ secrets.X }}, as flagged by zizmor.
+          #       If you really want to use a cache, consider splitting this
+          #       1 build+publish workflow into 2 separate build and publish workflows.
+          package-manager-cache: false
+          #cache: pnpm
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run docs:build

--- a/.github/workflows/deploy-docs-cloudflare.yml
+++ b/.github/workflows/deploy-docs-cloudflare.yml
@@ -10,7 +10,6 @@ on:
       - 'pnpm-lock.yaml'
       - 'wrangler.toml'
       - '.github/workflows/deploy-docs-cloudflare.yml'
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-agent-tui-macos.yml
+++ b/.github/workflows/e2e-agent-tui-macos.yml
@@ -57,18 +57,39 @@ jobs:
       - name: Install TUI agent dependencies
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"
-        run: |
+        # NOTE: ignore[adhoc-packages]: --min-release-age=N mitigates the ad-hoc
+        #       unlocked npm installs below
+        run: |  # zizmor: ignore[adhoc-packages]
           # fd/ripgrep are for pi: it downloads its own copies at first launch when they
           # are missing from PATH, which delays the TUI past the roundtrip timeout
-          brew install bats-core parallel tmux node aider block-goose-cli fd ripgrep
-          npm install --global --no-fund --no-audit \
+          # 1. Install Safehouse's own dependencies. (TODO: Consider pinning.)
+          # 2. Install latest unpinned versions of tools explicitly supported
+          #    as running inside a Safehouse sandbox
+          # NOTE: Does NOT use any kind of --min-release-age=N option
+          #       to reduce exposure to freshly-published supply chain
+          #       compromises because these formulae are all from homebrew-core
+          #       and thus are reviewed manually by a Homebrew maintainer
+          #       (not just the formula author) before publish.
+          brew install \
+            bats-core parallel \
+            aider block-goose-cli node tmux fd ripgrep
+          # NOTE: Uses --min-release-age=N to reduce exposure to
+          #       freshly-published supply chain compromises.
+          # NOTE: @sourcegraph/amp's version is pinned, unlike other packages here.
+          #       Bump the pin occasionally so it doesn't go too stale.
+          #      
+          #       All of amp's published versions are marked as prerelease but
+          #       --min-release-age=N only considers non-prerelease versions,
+          #       failing to find any valid version. An exact version pin
+          #       ignores prerelease-ness and succeeds.
+          npm install --global --no-fund --no-audit --min-release-age=4 \
             @anthropic-ai/claude-code \
             @earendil-works/pi-coding-agent \
             @github/copilot \
             @google/gemini-cli \
             @kilocode/cli \
             @openai/codex \
-            @sourcegraph/amp \
+            @sourcegraph/amp@0.0.1786054439-gd42f19 \
             cline \
             opencode-ai
 

--- a/.github/workflows/e2e-agent-tui-macos.yml
+++ b/.github/workflows/e2e-agent-tui-macos.yml
@@ -25,20 +25,26 @@ on:
       - ".github/workflows/e2e-agent-tui-macos.yml"
   workflow_dispatch:
 
+# Disallow all GITHUB_TOKEN permissions by default
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   e2e-tui-macos:
+    name: E2E TUI Tests (macOS)
     runs-on: macos-latest
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          persist-credentials: false
 
       - name: Cache npm download cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
         with:
           path: ~/.npm
           key: e2e-npm-${{ runner.os }}-${{ hashFiles('.github/workflows/e2e-agent-tui-macos.yml') }}
@@ -78,7 +84,7 @@ jobs:
 
       - name: Upload agent TUI logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: agent-tui-logs
           path: artifacts/e2e

--- a/.github/workflows/e2e-agent-tui-macos.yml
+++ b/.github/workflows/e2e-agent-tui-macos.yml
@@ -94,10 +94,15 @@ jobs:
             opencode-ai
 
       - name: Run agent TUI tests
+        # NOTE: ignore[secrets-outside-env]: This workflow can only run with
+        #       maintainer approval. Maintainer review of code pending merge
+        #       is considered sufficient protection against PR code
+        #       that tries to exfiltrate secrets. See discussion in:
+        #       https://github.com/eugene1g/agent-safehouse/issues/137
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}  # zizmor: ignore[secrets-outside-env]
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}  # zizmor: ignore[secrets-outside-env]
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}  # zizmor: ignore[secrets-outside-env]
           SAFEHOUSE_AGENT_TUI_STARTUP_WAIT_SECS: "20"
         run: |
           set -o pipefail

--- a/.github/workflows/regenerate-dist.yml
+++ b/.github/workflows/regenerate-dist.yml
@@ -11,19 +11,30 @@ on:
       - ".github/workflows/regenerate-dist.yml"
   workflow_dispatch:
 
-permissions:
-  contents: write
+# Disallow all GITHUB_TOKEN permissions by default; grant contents: write
+# per-job below, only where it's needed to push the regenerated artifacts.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   regenerate-dist-artifacts:
+    name: Regenerate Dist Artifacts
     runs-on: ubuntu-latest
+    # Needed to commit and push the regenerated dist artifacts back to the branch.
+    permissions:
+      contents: write  # push regenerated dist artifacts
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
+          # Credentials must persist so the "Commit and push" step below can push.
+          persist-credentials: true
 
       - name: Regenerate dist artifacts
         run: |

--- a/.github/workflows/regenerate-dist.yml
+++ b/.github/workflows/regenerate-dist.yml
@@ -11,8 +11,7 @@ on:
       - ".github/workflows/regenerate-dist.yml"
   workflow_dispatch:
 
-# Disallow all GITHUB_TOKEN permissions by default; grant contents: write
-# per-job below, only where it's needed to push the regenerated artifacts.
+# Disallow all GITHUB_TOKEN permissions by default
 permissions: {}
 
 concurrency:
@@ -23,17 +22,21 @@ jobs:
   regenerate-dist-artifacts:
     name: Regenerate Dist Artifacts
     runs-on: ubuntu-latest
-    # Needed to commit and push the regenerated dist artifacts back to the branch.
+    # Grant GitHub API write access, to commit/push the regenerated dist
+    # artifacts back to the branch.
     permissions:
       contents: write  # push regenerated dist artifacts
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        # NOTE: ignore[artipacked]: Persist GitHub API credentials so the
+        #       "Commit and push" step below can push
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6  # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
-          # Credentials must persist so the "Commit and push" step below can push.
+          # Persist GitHub API credentials so the
+          # "Commit and push" step below can push
           persist-credentials: true
 
       - name: Regenerate dist artifacts

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -17,17 +17,23 @@ on:
       - ".github/workflows/shell-lint.yml"
   workflow_dispatch:
 
+# Disallow all GITHUB_TOKEN permissions by default
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   lint-shell:
+    name: Shell Lint
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          persist-credentials: false
 
       - name: Install shellcheck and shfmt
         run: |

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -69,9 +69,30 @@ jobs:
       - name: Install test and browser dependencies
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"
-        run: |
-          brew install bats-core parallel node fnm
+        # NOTE: ignore[adhoc-packages]: --min-release-age=N mitigates the ad-hoc
+        #       unlocked npm installs below
+        run: |  # zizmor: ignore[adhoc-packages]
+          # 1. Install Safehouse's own dependencies. (TODO: Consider pinning.)
+          # 2. Install latest unpinned versions of tools explicitly supported
+          #    as running inside a Safehouse sandbox
+          # NOTE: Does NOT use any kind of --min-release-age=N option
+          #       to reduce exposure to freshly-published supply chain
+          #       compromises because these formulae are all from homebrew-core
+          #       and thus are reviewed manually by a Homebrew maintainer
+          #       (not just the formula author) before publish.
+          brew install \
+            bats-core parallel \
+            fnm node
+          # NOTE: --cask marks vendor-built items (not built by Homebrew).
+          #       Integrity checking varies: temurin is currently pinned;
+          #       google-chrome is currently unpinned.
           brew install --cask google-chrome temurin
+          # NOTE: Uses --min-release-age=N to reduce exposure to
+          #       freshly-published supply chain compromises.
+          npm install --global --no-fund --no-audit --min-release-age=4 \
+            agent-browser playwright
+
+          # Configure temurin
           shopt -s nullglob
           temurin_homes=(/Library/Java/JavaVirtualMachines/temurin*.jdk/Contents/Home)
           shopt -u nullglob
@@ -81,7 +102,7 @@ jobs:
           fi
           printf 'JAVA_HOME=%s\n' "${temurin_homes[0]}" >> "${GITHUB_ENV}"
           printf '%s\n' "${temurin_homes[0]}/bin" >> "${GITHUB_PATH}"
-          npm install --global --no-fund --no-audit agent-browser playwright
+
           agent-browser install
           playwright install chromium-headless-shell
 

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -39,12 +39,16 @@ on:
       - ".github/workflows/regenerate-dist.yml"
   workflow_dispatch:
 
+# Disallow all GITHUB_TOKEN permissions by default
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   test-macos:
+    name: Tests (macOS)
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +62,9 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          persist-credentials: false
 
       - name: Install test and browser dependencies
         env:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,39 @@
+name: Workflow Lint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+# Disallow all GITHUB_TOKEN permissions by default
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+
+      # NOTE: Runs offline (no GH_TOKEN) since we don't need zizmor's
+      #       online-only audits, which mainly detect stale action-pin
+      #       comments (e.g. "# v6" no longer matching the pinned SHA).
+      - name: Run zizmor (auditor persona)
+        run: uvx "zizmor@1.29.0" --persona auditor .github/workflows/

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -25,6 +25,9 @@ export default {
     }
 
     // For non-API routes, delegate to static assets.
+    // TODO: Serve an HTTP 404 instead. This code should be unreachable
+    //       because wrangler.toml should have served a static asset for any
+    //       non-/api/* route.
     return env.ASSETS.fetch(request);
   },
 };


### PR DESCRIPTION
In particular:

- Fix straightforward zizmor diagnostics
- Disable unsafe cache usage in workflow: deploy-docs-cloudflare.yml
- Mark intentional reuse of GitHub credential in workflow: regenerate-dist.yml
- For unpinned tool versions, prevent using versions published <4 days ago
    - Side effect: Must pin `@sourcegraph/amp` to a specific version rather than floating it, because amp's apparent policy of only ever publishing prerelease versions conflicts with using npm's `--min-release-age=N` option.
- Disable ability to generate docs against non-main branch
- Document mitigations against secret exfiltration risk flagged by `[secrets-outside-env]` zizmor diagnostic
- Run zizmor in CI upon workflow changes

Closes #137.
