### PR TITLE
test(network): reap the nc listeners on failure

### DIFF
--- a/tests/policy/runtime/network.bats
+++ b/tests/policy/runtime/network.bats
@@ -8,6 +8,18 @@
 #
 load ../../test_helper.bash
 
+# Overrides the shared teardown (test_helper.bash) to also reap the listener, which the
+# in-test cleanup misses when a test aborts on a failed assertion. A leaked listener
+# keeps holding its port, so it breaks the next run of the test too.
+teardown() {
+  if [ -n "${nc_pid:-}" ]; then
+    kill "$nc_pid" 2>/dev/null || true
+    wait "$nc_pid" 2>/dev/null || true
+  fi
+
+  sft_teardown_test_env
+}
+
 @test "[POLICY-ONLY] default profile uses narrowed IP outbound rules, not broad network*" { # https://github.com/eugene1g/agent-safehouse/issues/99
   local profile
   profile="$(safehouse_profile)"
@@ -21,7 +33,7 @@ load ../../test_helper.bash
 }
 
 @test "[EXECUTION] default sandbox denies outbound to UNIX-domain sockets" { # https://github.com/eugene1g/agent-safehouse/issues/99
-  local socket_path nc_pid
+  local socket_path  # nc_pid stays global for teardown
 
   socket_path="${BATS_TEST_TMPDIR}/test-unix-$$.sock"
   nc -lU "$socket_path" &
@@ -30,22 +42,15 @@ load ../../test_helper.bash
 
   safehouse_denied -- /bin/sh -c "nc -U '$socket_path' </dev/null 2>&1"
 
-  kill "$nc_pid" 2>/dev/null || true  # ignore error if nc exited early
-  wait "$nc_pid" 2>/dev/null || true  # ignore SIGTERM from kill
   rm -f "$socket_path"
 }
 
 @test "[EXECUTION] default sandbox allows outbound TCP to IP destinations" { # https://github.com/eugene1g/agent-safehouse/issues/99
-  local nc_pid
-
-  nc -l 127.0.0.1 19753 &
+  nc -l 127.0.0.1 19753 &  # nc_pid stays global for teardown
   nc_pid=$!
   sleep 0.3
 
   safehouse_ok -- /bin/sh -c "printf '' | nc 127.0.0.1 19753 >/dev/null 2>&1"
-
-  kill "$nc_pid" 2>/dev/null || true  # ignore error if nc exited early
-  wait "$nc_pid" 2>/dev/null || true  # ignore SIGTERM from kill
 }
 
 @test "[EXECUTION] default sandbox allows DNS resolution via mDNSResponder" { # https://github.com/eugene1g/agent-safehouse/issues/99


### PR DESCRIPTION
Both listener-based tests in `tests/policy/runtime/network.bats` killed their backgrounded `nc` in the last lines of the test body, which a failed assertion skips: bats aborts the test at that point and the listener stays up. Unlike a sleeping process it never exits on its own and keeps holding its port, so one failed run of the TCP test breaks the next run of it as well.

Moves the cleanup into a `teardown` (which still calls the shared `sft_teardown_test_env`) so it runs on every exit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
