### PR TITLE
CI: Refuse to run a dist/safehouse.sh that is not up-to-date

### DIFF
--- a/.github/workflows/e2e-agent-tui-macos.yml
+++ b/.github/workflows/e2e-agent-tui-macos.yml
@@ -43,6 +43,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # Refuse to run dist/safehouse.sh if it is inconsistent with a
+      # fresh regeneration, so a PR can't smuggle in arbitrary code,
+      # past a maintainer's lightweight review of whether it is safe
+      # to run CI workflows on a PR.
+      - name: Verify dist/safehouse.sh matches source
+        run: ./scripts/generate-dist.sh --check
+
       - name: Cache npm download cache
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
         with:

--- a/.github/workflows/regenerate-dist.yml
+++ b/.github/workflows/regenerate-dist.yml
@@ -52,39 +52,6 @@ jobs:
             exit 0
           fi
 
-          changed_dist_files="$(git diff --cached --name-only -- dist)"
-          only_safehouse_sh=1
-          while IFS= read -r changed_file; do
-            [[ -n "$changed_file" ]] || continue
-            if [[ "$changed_file" != "dist/safehouse.sh" ]]; then
-              only_safehouse_sh=0
-              break
-            fi
-          done <<< "$changed_dist_files"
-
-          if [[ "$only_safehouse_sh" -eq 1 ]]; then
-            has_non_timestamp_diff=0
-            while IFS= read -r line; do
-              case "$line" in
-                "diff --git "*|"index "*|"--- "*|"+++ "*|"@@ "*|"")
-                  continue
-                  ;;
-                "+# Embedded Profiles Last Modified (UTC): "*|"-# Embedded Profiles Last Modified (UTC): "*)
-                  continue
-                  ;;
-                *)
-                  has_non_timestamp_diff=1
-                  break
-                  ;;
-              esac
-            done < <(GIT_EXTERNAL_DIFF= git --no-pager diff --cached --no-ext-diff --no-color --unified=0 -- dist/safehouse.sh)
-
-            if [[ "$has_non_timestamp_diff" -eq 0 ]]; then
-              echo "Only dist/safehouse.sh embedded profile timestamp changed; skipping commit."
-              exit 0
-            fi
-          fi
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: regenerate dist artifacts"

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -66,6 +66,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # Refuse to run dist/safehouse.sh if it is inconsistent with a
+      # fresh regeneration, so a PR can't smuggle in arbitrary code,
+      # past a maintainer's lightweight review of whether it is safe
+      # to run CI workflows on a PR.
+      - name: Verify dist/safehouse.sh matches source
+        run: ./scripts/generate-dist.sh --check
+
       - name: Install test and browser dependencies
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"

--- a/scripts/generate-dist.sh
+++ b/scripts/generate-dist.sh
@@ -8,6 +8,7 @@ output_dir="${ROOT_DIR}/dist"
 output_path="${output_dir}/safehouse.sh"
 output_path_explicit=0
 output_dir_explicit=0
+check_mode=0
 
 project_version_file="${ROOT_DIR}/VERSION"
 project_version_placeholder="__SAFEHOUSE_PROJECT_VERSION__"
@@ -30,7 +31,7 @@ dist_preassembled_core_integration_keys=()
 usage() {
   cat <<USAGE
 Usage:
-  $(basename "$0") [--output PATH] [--output-dir PATH]
+  $(basename "$0") [--output PATH] [--output-dir PATH] [--check]
 
 Description:
   Generate the committed dist executable:
@@ -42,6 +43,11 @@ Options:
 
   --output-dir PATH
       Directory for dist executable output (default: ${output_dir})
+
+  --check
+      Do not write the output file. Instead, verify that it already matches
+      a fresh regeneration. Exits 0 if up to date or 1 with a diff.
+      Useful in CI to confirm a committed dist artifact wasn't hand-edited.
 
   -h, --help
       Show this help
@@ -910,23 +916,46 @@ emit_self_update_validation_marker() {
 SCRIPT
 }
 
-write_dist_script() {
-  local target_path="$1"
+# Returns 0 if the two input files are the same or differ only in timestamp,
+# or 1 otherwise.
+dist_only_timestamp_differs() {
+  local file_a="$1"
+  local file_b="$2"
+  local line
+
+  if diff -q "$file_a" "$file_b" >/dev/null; then
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    case "$line" in
+      "--- "* | "+++ "* | "@@ "* | "" | " "*)
+        continue
+        ;;
+      "+# Embedded Profiles Last Modified (UTC): "* | "-# Embedded Profiles Last Modified (UTC): "*)
+        continue
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  done < <(diff -u "$file_a" "$file_b" || true)
+
+  return 0
+}
+
+render_dist_script() {
+  local target_output="$1"
   local embedded_profiles_last_modified_utc="$2"
   local project_version="$3"
-  local tmp_output
-
-  mkdir -p "$(dirname "$target_path")"
-  tmp_output="$(mktemp "${target_path}.XXXXXX")"
 
   {
     emit_dist_script_body "$embedded_profiles_last_modified_utc" "$project_version"
     echo 'safehouse_main "$@"'
     emit_self_update_validation_marker
-  } >"$tmp_output"
+  } >"$target_output"
 
-  chmod 0755 "$tmp_output"
-  mv "$tmp_output" "$target_path"
+  chmod 0755 "$target_output"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -959,6 +988,10 @@ while [[ $# -gt 0 ]]; do
       output_dir_explicit=1
       shift
       ;;
+    --check)
+      check_mode=1
+      shift
+      ;;
     -h | --help)
       usage
       exit 0
@@ -983,7 +1016,36 @@ validate_embedded_agent_command_alias_catalog
 project_version="$(read_project_version)"
 embedded_profiles_last_modified_utc="$(resolve_embedded_profiles_last_modified_utc)"
 
-write_dist_script "$output_path" "$embedded_profiles_last_modified_utc" "$project_version"
+# Write generate-dist.sh to scratch file
+scratch_output="$(mktemp "${output_path}.XXXXXX")"
+trap 'rm -f "$scratch_output"' EXIT
+render_dist_script "$scratch_output" "$embedded_profiles_last_modified_utc" "$project_version"
+
+if [[ "$check_mode" -eq 1 ]]; then
+  if [[ ! -f "$output_path" ]]; then
+    echo "Missing dist artifact: ${output_path}" >&2
+    exit 1
+  fi
+
+  if dist_only_timestamp_differs "$output_path" "$scratch_output"; then
+    # Matches a fresh regeneration
+    exit 0
+  else
+    # Differs from a fresh regeneration
+    diff -u "$output_path" "$scratch_output" >&2 || true
+    exit 1
+  fi
+fi
+
+if [[ -f "$output_path" ]] && dist_only_timestamp_differs "$output_path" "$scratch_output"; then
+  # Already up to date
+  :
+else
+  # Move new generate-dist.sh to its final location
+  mkdir -p "$(dirname "$output_path")"
+  mv "$scratch_output" "$output_path"
+fi
+
 cleanup_committed_obsolete_dist_artifacts
 
 printf '%s\n' "$output_path"

--- a/scripts/generate-dist.sh
+++ b/scripts/generate-dist.sh
@@ -1017,6 +1017,7 @@ project_version="$(read_project_version)"
 embedded_profiles_last_modified_utc="$(resolve_embedded_profiles_last_modified_utc)"
 
 # Write generate-dist.sh to scratch file
+mkdir -p "$(dirname "$output_path")"
 scratch_output="$(mktemp "${output_path}.XXXXXX")"
 trap 'rm -f "$scratch_output"' EXIT
 render_dist_script "$scratch_output" "$embedded_profiles_last_modified_utc" "$project_version"
@@ -1042,7 +1043,6 @@ if [[ -f "$output_path" ]] && dist_only_timestamp_differs "$output_path" "$scrat
   :
 else
   # Move new generate-dist.sh to its final location
-  mkdir -p "$(dirname "$output_path")"
   mv "$scratch_output" "$output_path"
 fi
 


### PR DESCRIPTION
Specifically:
* scripts/generate-dist.sh: Don't alter dist/safehouse.sh if only a timestamp would be updated
* scripts/generate-dist.sh: Add a --check mode that returns 0 only if dist/safehouse.sh is fresh
* Any workflows that run tests now verify that dist/safehouse.sh is up-to-date (and hasn't been tampered with)

This change makes it safer for maintainers to approve workflow runs on incoming PRs, because it ensures that the dist/safehouse.sh which appears in a PR is faithful to any modified .sb files in the PR and hasn't been tampered with.